### PR TITLE
perf: Cache Playwright browsers in E2E CI

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -10,11 +10,6 @@ jobs:
   e2e:
     name: Playwright E2E Tests
     runs-on: ubuntu-latest
-    container:
-      image: mcr.microsoft.com/playwright:v1.50.0-noble
-      options: >-
-        --user root
-        -v /var/run/docker.sock:/var/run/docker.sock
 
     steps:
       - uses: actions/checkout@v4
@@ -28,18 +23,29 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      # No Playwright browser install needed - pre-installed in container!
+      - name: Get Playwright version
+        id: playwright-version
+        run: echo "version=$(npm ls @playwright/test --json | jq -r '.dependencies["@playwright/test"].version')" >> $GITHUB_OUTPUT
 
-      - name: Install Docker CLI
-        run: |
-          apt-get update
-          apt-get install -y docker.io
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
 
-      - name: Install Supabase CLI
-        run: |
-          cd /tmp
-          curl -sSL https://github.com/supabase/cli/releases/latest/download/supabase_linux_amd64.tar.gz | tar xz
-          mv supabase /usr/local/bin/
+      - name: Install Playwright Browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: npx playwright install chromium --with-deps
+
+      - name: Install Playwright system deps (if cached)
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps chromium
+
+      - name: Setup Supabase CLI
+        uses: supabase/setup-cli@v1
+        with:
+          version: latest
 
       - name: Start Supabase
         run: |


### PR DESCRIPTION
## Summary

Adds browser caching to speed up E2E tests in CI.

**What changed:**
- Cache Playwright browser binaries between runs
- Only install Chromium (already on main)
- On cache miss: Full browser download (~2-3 min)
- On cache hit: Only install system deps (~10-20 seconds)

**Why not use Playwright container?**
Attempted using `mcr.microsoft.com/playwright` container with Docker socket mounting, but Supabase containers on the host can't be reached via `127.0.0.1` from inside the workflow container due to network namespace isolation.

## Test plan

- [ ] First run downloads and caches browsers
- [ ] Subsequent runs hit cache and skip browser download
- [ ] E2E tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)