### PR TITLE
feat: practice mode for problems

### DIFF
--- a/e2e/session-lifecycle.spec.ts
+++ b/e2e/session-lifecycle.spec.ts
@@ -210,8 +210,15 @@ describeE2E('Session Lifecycle', () => {
       const monacoEditor2 = page.locator('.monaco-editor').first();
       await monacoEditor2.click();
       await page.keyboard.press('ControlOrMeta+a');
+      await expect(async () => {
+        // Wait for select-all to register
+        const text = await page.evaluate(() => window.getSelection()?.toString() || '');
+        expect(text.length).toBeGreaterThan(0);
+      }).toPass({ timeout: 2000 }).catch(() => {
+        // Selection may be empty for empty editor, that's OK
+      });
       await page.keyboard.press('Backspace');
-      await page.keyboard.type(studentCode2, { delay: 30 });
+      await page.keyboard.type(studentCode2, { delay: 50 });
 
       console.log('Student typed code in second session');
 
@@ -255,8 +262,8 @@ describeE2E('Session Lifecycle', () => {
       await page.locator('button:has-text("Run Code")').click();
 
       // Verify output panel shows execution result
-      // The output should appear in a panel/area showing the print statement result
-      await expect(page.locator('text=FIBONACCI_TEST_67890')).toBeVisible({ timeout: 15000 });
+      // Practice mode execution should complete within 10 seconds
+      await expect(page.locator('text=FIBONACCI_TEST_67890')).toBeVisible({ timeout: 10000 });
 
       console.log('Practice mode execution successful!');
       console.log('Session lifecycle test completed successfully!');

--- a/src/app/(fullscreen)/student/page.tsx
+++ b/src/app/(fullscreen)/student/page.tsx
@@ -172,6 +172,9 @@ function StudentPage() {
   useEffect(() => {
     if (session?.status === 'completed' && session?.id === sessionIdFromUrl) {
       setSessionEnded(true);
+    } else if (session?.id && session?.id !== sessionIdFromUrl) {
+      // If session data loaded but it's for a different session, reset the ended flag
+      setSessionEnded(false);
     }
   }, [session?.status, session?.id, sessionIdFromUrl]);
 

--- a/src/app/(fullscreen)/student/page.tsx
+++ b/src/app/(fullscreen)/student/page.tsx
@@ -394,7 +394,8 @@ function StudentPage() {
       )}
 
       {/* Session Ended Banner */}
-      {sessionEnded && (
+      {/* Only show if session is actually ended AND matches current URL */}
+      {sessionEnded && session?.id === sessionIdFromUrl && session?.status === 'completed' && (
         <SessionEndedNotification
           onLeaveToDashboard={handleLeaveSession}
           code={code}

--- a/src/app/(fullscreen)/student/page.tsx
+++ b/src/app/(fullscreen)/student/page.tsx
@@ -124,7 +124,8 @@ function StudentPage() {
           setIsJoining(false);
           setError(null);
           // For completed sessions, set sessionEnded flag
-          if (session.status === 'completed') {
+          // Only if this is actually the session we joined (not stale data from previous session)
+          if (session.status === 'completed' && session.id === sessionIdFromUrl) {
             setSessionEnded(true);
           }
           // Restore saved code and execution settings from server
@@ -167,11 +168,12 @@ function StudentPage() {
   }, [sessionIdFromUrl]);
 
   // Detect when session ends (status changes to 'completed')
+  // Only if this is the current session (not stale data from a previous session)
   useEffect(() => {
-    if (session?.status === 'completed') {
+    if (session?.status === 'completed' && session?.id === sessionIdFromUrl) {
       setSessionEnded(true);
     }
-  }, [session?.status]);
+  }, [session?.status, session?.id, sessionIdFromUrl]);
 
   // Debounced code update (keeping 500ms to match original behavior)
   // Allows saving in completed sessions (practice mode)

--- a/src/app/(public)/problems/[id]/StudentActions.tsx
+++ b/src/app/(public)/problems/[id]/StudentActions.tsx
@@ -1,0 +1,171 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useAuth } from '@/contexts/AuthContext';
+import { useRouter } from 'next/navigation';
+
+interface StudentActionsProps {
+  problemId: string;
+  classId: string;
+}
+
+interface Section {
+  id: string;
+  classId: string;
+  name: string;
+  role: 'student' | 'instructor';
+}
+
+export default function StudentActions({ problemId, classId }: StudentActionsProps) {
+  const { user, isLoading } = useAuth();
+  const [studentSections, setStudentSections] = useState<Section[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [showPicker, setShowPicker] = useState(false);
+  const [selectedSectionId, setSelectedSectionId] = useState<string | null>(null);
+  const router = useRouter();
+
+  // Fetch student's sections for this class
+  useEffect(() => {
+    if (isLoading || !user) return;
+
+    const fetchSections = async () => {
+      try {
+        const response = await fetch('/api/sections/my');
+        if (!response.ok) {
+          throw new Error('Failed to load sections');
+        }
+        const data = await response.json();
+        const sections: Section[] = data.sections || [];
+
+        // Filter to only sections where user is a student in this class
+        const filtered = sections.filter(
+          (section) => section.classId === classId && section.role === 'student'
+        );
+
+        setStudentSections(filtered);
+      } catch (err) {
+        console.error('Error fetching sections:', err);
+        setStudentSections([]);
+      }
+    };
+
+    fetchSections();
+  }, [isLoading, user, classId]);
+
+  // Don't render if loading or not authenticated
+  if (isLoading || !user) return null;
+
+  // Don't render if user has no student sections in this class
+  if (studentSections.length === 0) return null;
+
+  const handlePracticeClick = () => {
+    // If only one section, auto-start
+    if (studentSections.length === 1) {
+      startPractice(studentSections[0].id);
+    } else {
+      // Show section picker
+      setShowPicker(true);
+    }
+  };
+
+  const startPractice = async (sectionId: string) => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const response = await fetch(`/api/problems/${problemId}/practice`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ sectionId }),
+      });
+
+      if (!response.ok) {
+        const data = await response.json();
+        throw new Error(data.error || 'Failed to start practice session');
+      }
+
+      const { sessionId } = await response.json();
+      router.push(`/student?sessionId=${sessionId}`);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to start practice session');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleSectionSelect = (sectionId: string) => {
+    setSelectedSectionId(sectionId);
+  };
+
+  const handleStartPractice = () => {
+    if (selectedSectionId) {
+      setShowPicker(false);
+      startPractice(selectedSectionId);
+    }
+  };
+
+  return (
+    <>
+      <div className="flex items-center gap-3 mb-6">
+        <button
+          onClick={handlePracticeClick}
+          disabled={loading}
+          className="px-4 py-2 text-sm bg-green-600 text-white hover:bg-green-700 rounded-lg transition-colors disabled:opacity-50"
+        >
+          {loading ? (
+            <span className="flex items-center gap-2">
+              <svg className="animate-spin h-4 w-4" fill="none" viewBox="0 0 24 24">
+                <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+                <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+              </svg>
+              Starting...
+            </span>
+          ) : (
+            'Practice'
+          )}
+        </button>
+      </div>
+
+      {error && (
+        <p className="text-sm text-red-600 mb-4">{error}</p>
+      )}
+
+      {showPicker && (
+        <div className="mb-6 p-4 border border-gray-300 rounded-lg bg-white">
+          <h3 className="text-lg font-semibold mb-3">Select Section</h3>
+          <div className="space-y-2">
+            {studentSections.map((section) => (
+              <label key={section.id} className="flex items-center gap-2 cursor-pointer">
+                <input
+                  type="radio"
+                  name="section"
+                  value={section.id}
+                  checked={selectedSectionId === section.id}
+                  onChange={() => handleSectionSelect(section.id)}
+                  className="w-4 h-4"
+                />
+                <span className="text-sm">{section.name}</span>
+              </label>
+            ))}
+          </div>
+          <div className="mt-4 flex gap-2">
+            <button
+              onClick={handleStartPractice}
+              disabled={!selectedSectionId}
+              className="px-4 py-2 text-sm bg-green-600 text-white hover:bg-green-700 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              Start Practice
+            </button>
+            <button
+              onClick={() => setShowPicker(false)}
+              className="px-4 py-2 text-sm bg-gray-200 text-gray-800 hover:bg-gray-300 rounded-lg transition-colors"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/app/(public)/problems/[id]/__tests__/StudentActions.test.tsx
+++ b/src/app/(public)/problems/[id]/__tests__/StudentActions.test.tsx
@@ -1,0 +1,379 @@
+/**
+ * Tests for StudentActions component
+ */
+
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useRouter } from 'next/navigation';
+import StudentActions from '../StudentActions';
+import { useAuth } from '@/contexts/AuthContext';
+
+// Mock dependencies
+jest.mock('next/navigation', () => ({
+  useRouter: jest.fn(),
+}));
+
+jest.mock('@/contexts/AuthContext', () => ({
+  useAuth: jest.fn(),
+}));
+
+// Mock fetch globally
+global.fetch = jest.fn();
+
+describe('StudentActions', () => {
+  const mockRouter = {
+    push: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useRouter as jest.Mock).mockReturnValue(mockRouter);
+    (global.fetch as jest.Mock).mockClear();
+  });
+
+  describe('visibility', () => {
+    it('should not render when user is loading', () => {
+      (useAuth as jest.Mock).mockReturnValue({
+        user: null,
+        isLoading: true,
+      });
+
+      const { container } = render(
+        <StudentActions problemId="prob-1" classId="class-1" />
+      );
+      expect(container.firstChild).toBeNull();
+    });
+
+    it('should not render when user is not authenticated', () => {
+      (useAuth as jest.Mock).mockReturnValue({
+        user: null,
+        isLoading: false,
+      });
+
+      const { container } = render(
+        <StudentActions problemId="prob-1" classId="class-1" />
+      );
+      expect(container.firstChild).toBeNull();
+    });
+
+    it('should not render when user has no student sections in this class', async () => {
+      (useAuth as jest.Mock).mockReturnValue({
+        user: { id: 'user-1', email: 'test@example.com', role: 'student' },
+        isLoading: false,
+      });
+
+      // Mock API response - no sections for this class
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          sections: [
+            { id: 'sec-1', classId: 'other-class', role: 'student', name: 'Section 1' },
+          ],
+        }),
+      });
+
+      const { container } = render(
+        <StudentActions problemId="prob-1" classId="class-1" />
+      );
+
+      // Wait for API call and render
+      await waitFor(() => {
+        expect(global.fetch).toHaveBeenCalledWith('/api/sections/my');
+      });
+
+      // Should not render if no matching sections
+      expect(container.firstChild).toBeNull();
+    });
+
+    it('should render Practice button when user is a student in a section of this class', async () => {
+      (useAuth as jest.Mock).mockReturnValue({
+        user: { id: 'user-1', email: 'test@example.com', role: 'student' },
+        isLoading: false,
+      });
+
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          sections: [
+            { id: 'sec-1', classId: 'class-1', role: 'student', name: 'Section 1' },
+          ],
+        }),
+      });
+
+      render(<StudentActions problemId="prob-1" classId="class-1" />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Practice')).toBeInTheDocument();
+      });
+    });
+
+    it('should render Practice button when user is instructor in one class but student in this class', async () => {
+      (useAuth as jest.Mock).mockReturnValue({
+        user: { id: 'user-1', email: 'test@example.com', role: 'instructor' },
+        isLoading: false,
+      });
+
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          sections: [
+            { id: 'sec-1', classId: 'other-class', role: 'instructor', name: 'Section 1' },
+            { id: 'sec-2', classId: 'class-1', role: 'student', name: 'Section 2' },
+          ],
+        }),
+      });
+
+      render(<StudentActions problemId="prob-1" classId="class-1" />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Practice')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('practice session creation', () => {
+    it('should auto-start practice with single section', async () => {
+      (useAuth as jest.Mock).mockReturnValue({
+        user: { id: 'user-1', email: 'test@example.com', role: 'student' },
+        isLoading: false,
+      });
+
+      (global.fetch as jest.Mock)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            sections: [
+              { id: 'sec-1', classId: 'class-1', role: 'student', name: 'Section 1' },
+            ],
+          }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ sessionId: 'session-123' }),
+        });
+
+      render(<StudentActions problemId="prob-1" classId="class-1" />);
+
+      const practiceButton = await screen.findByText('Practice');
+      await userEvent.click(practiceButton);
+
+      await waitFor(() => {
+        expect(global.fetch).toHaveBeenCalledWith(
+          '/api/problems/prob-1/practice',
+          expect.objectContaining({
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ sectionId: 'sec-1' }),
+          })
+        );
+      });
+
+      expect(mockRouter.push).toHaveBeenCalledWith('/student?sessionId=session-123');
+    });
+
+    it('should show section picker with multiple sections', async () => {
+      (useAuth as jest.Mock).mockReturnValue({
+        user: { id: 'user-1', email: 'test@example.com', role: 'student' },
+        isLoading: false,
+      });
+
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          sections: [
+            { id: 'sec-1', classId: 'class-1', role: 'student', name: 'Section 1' },
+            { id: 'sec-2', classId: 'class-1', role: 'student', name: 'Section 2' },
+          ],
+        }),
+      });
+
+      render(<StudentActions problemId="prob-1" classId="class-1" />);
+
+      const practiceButton = await screen.findByText('Practice');
+      await userEvent.click(practiceButton);
+
+      // Should show section picker
+      await waitFor(() => {
+        expect(screen.getByText('Select Section')).toBeInTheDocument();
+      });
+
+      expect(screen.getByText('Section 1')).toBeInTheDocument();
+      expect(screen.getByText('Section 2')).toBeInTheDocument();
+    });
+
+    it('should create practice session after selecting section from picker', async () => {
+      (useAuth as jest.Mock).mockReturnValue({
+        user: { id: 'user-1', email: 'test@example.com', role: 'student' },
+        isLoading: false,
+      });
+
+      (global.fetch as jest.Mock)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            sections: [
+              { id: 'sec-1', classId: 'class-1', role: 'student', name: 'Section 1' },
+              { id: 'sec-2', classId: 'class-1', role: 'student', name: 'Section 2' },
+            ],
+          }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ sessionId: 'session-456' }),
+        });
+
+      render(<StudentActions problemId="prob-1" classId="class-1" />);
+
+      const practiceButton = await screen.findByText('Practice');
+      await userEvent.click(practiceButton);
+
+      // Wait for picker to appear
+      const section2Option = await screen.findByText('Section 2');
+      await userEvent.click(section2Option);
+
+      // Click Start Practice button in picker
+      const startButton = screen.getByText('Start Practice');
+      await userEvent.click(startButton);
+
+      await waitFor(() => {
+        expect(global.fetch).toHaveBeenCalledWith(
+          '/api/problems/prob-1/practice',
+          expect.objectContaining({
+            method: 'POST',
+            body: JSON.stringify({ sectionId: 'sec-2' }),
+          })
+        );
+      });
+
+      expect(mockRouter.push).toHaveBeenCalledWith('/student?sessionId=session-456');
+    });
+
+    it('should show loading state during session creation', async () => {
+      (useAuth as jest.Mock).mockReturnValue({
+        user: { id: 'user-1', email: 'test@example.com', role: 'student' },
+        isLoading: false,
+      });
+
+      let resolveFetch: any;
+      const fetchPromise = new Promise((resolve) => {
+        resolveFetch = resolve;
+      });
+
+      (global.fetch as jest.Mock)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            sections: [
+              { id: 'sec-1', classId: 'class-1', role: 'student', name: 'Section 1' },
+            ],
+          }),
+        })
+        .mockReturnValueOnce(fetchPromise);
+
+      render(<StudentActions problemId="prob-1" classId="class-1" />);
+
+      const practiceButton = await screen.findByText('Practice');
+      await userEvent.click(practiceButton);
+
+      // Should show loading state
+      await waitFor(() => {
+        expect(screen.getByText('Starting...')).toBeInTheDocument();
+      });
+
+      // Complete the request
+      resolveFetch({
+        ok: true,
+        json: async () => ({ sessionId: 'session-123' }),
+      });
+
+      await waitFor(() => {
+        expect(mockRouter.push).toHaveBeenCalled();
+      });
+    });
+
+    it('should handle API errors gracefully', async () => {
+      (useAuth as jest.Mock).mockReturnValue({
+        user: { id: 'user-1', email: 'test@example.com', role: 'student' },
+        isLoading: false,
+      });
+
+      (global.fetch as jest.Mock)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            sections: [
+              { id: 'sec-1', classId: 'class-1', role: 'student', name: 'Section 1' },
+            ],
+          }),
+        })
+        .mockResolvedValueOnce({
+          ok: false,
+          json: async () => ({ error: 'Not enrolled' }),
+        });
+
+      render(<StudentActions problemId="prob-1" classId="class-1" />);
+
+      const practiceButton = await screen.findByText('Practice');
+      await userEvent.click(practiceButton);
+
+      await waitFor(() => {
+        expect(screen.getByText(/Not enrolled/)).toBeInTheDocument();
+      });
+    });
+
+    it('should handle sections API failure gracefully', async () => {
+      (useAuth as jest.Mock).mockReturnValue({
+        user: { id: 'user-1', email: 'test@example.com', role: 'student' },
+        isLoading: false,
+      });
+
+      (global.fetch as jest.Mock).mockRejectedValueOnce(new Error('Network error'));
+
+      const { container } = render(<StudentActions problemId="prob-1" classId="class-1" />);
+
+      // Wait for API call to fail
+      await waitFor(() => {
+        expect(global.fetch).toHaveBeenCalledWith('/api/sections/my');
+      });
+
+      // Should not render if sections fetch fails
+      expect(container.firstChild).toBeNull();
+    });
+
+    it('should close section picker when Cancel is clicked', async () => {
+      (useAuth as jest.Mock).mockReturnValue({
+        user: { id: 'user-1', email: 'test@example.com', role: 'student' },
+        isLoading: false,
+      });
+
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          sections: [
+            { id: 'sec-1', classId: 'class-1', role: 'student', name: 'Section 1' },
+            { id: 'sec-2', classId: 'class-1', role: 'student', name: 'Section 2' },
+          ],
+        }),
+      });
+
+      render(<StudentActions problemId="prob-1" classId="class-1" />);
+
+      const practiceButton = await screen.findByText('Practice');
+      await userEvent.click(practiceButton);
+
+      // Wait for picker to appear
+      await waitFor(() => {
+        expect(screen.getByText('Select Section')).toBeInTheDocument();
+      });
+
+      // Click Cancel button
+      const cancelButton = screen.getByText('Cancel');
+      await userEvent.click(cancelButton);
+
+      // Picker should be hidden
+      await waitFor(() => {
+        expect(screen.queryByText('Select Section')).not.toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/src/app/(public)/problems/[id]/__tests__/page.test.tsx
+++ b/src/app/(public)/problems/[id]/__tests__/page.test.tsx
@@ -34,6 +34,12 @@ jest.mock('../InstructorActions', () => {
   };
 });
 
+jest.mock('../StudentActions', () => {
+  return function MockStudentActions() {
+    return <div data-testid="student-actions" />;
+  };
+});
+
 jest.mock('../SolutionBlock', () => {
   return function MockSolutionBlock({ html }: { html: string }) {
     return <div data-testid="solution-block" dangerouslySetInnerHTML={{ __html: html }} />;

--- a/src/app/(public)/problems/[id]/page.tsx
+++ b/src/app/(public)/problems/[id]/page.tsx
@@ -16,6 +16,7 @@ import { SERVICE_ROLE_MARKER } from '@/server/supabase/client';
 import MarkdownContent from '@/components/MarkdownContent';
 import SolutionBlock from './SolutionBlock';
 import InstructorActions from './InstructorActions';
+import StudentActions from './StudentActions';
 
 type Params = {
   params: Promise<{ id: string }>;
@@ -77,6 +78,9 @@ export default async function PublicProblemPage({ params }: Params) {
 
       <Suspense fallback={null}>
         <InstructorActions problemId={problem.id} problemTitle={problem.title} classId={problem.classId} className={className} />
+      </Suspense>
+      <Suspense fallback={null}>
+        <StudentActions problemId={problem.id} classId={problem.classId} />
       </Suspense>
 
       {problem.description && (

--- a/src/app/api/problems/[id]/practice/__tests__/route.test.ts
+++ b/src/app/api/problems/[id]/practice/__tests__/route.test.ts
@@ -452,7 +452,7 @@ describe('POST /api/problems/[id]/practice', () => {
     const data = await response.json();
 
     expect(response.status).toBe(500);
-    expect(data.error).toBe('Failed to create session');
+    expect(data.error).toBe('Failed to create practice session');
   });
 
   it('should handle errors when adding student fails', async () => {
@@ -474,7 +474,7 @@ describe('POST /api/problems/[id]/practice', () => {
     const data = await response.json();
 
     expect(response.status).toBe(500);
-    expect(data.error).toBe('Failed to add student');
+    expect(data.error).toBe('Failed to create practice session');
   });
 
   it('should respect rate limiting', async () => {

--- a/src/app/api/problems/[id]/practice/__tests__/route.test.ts
+++ b/src/app/api/problems/[id]/practice/__tests__/route.test.ts
@@ -1,0 +1,543 @@
+/**
+ * Tests for /api/problems/[id]/practice endpoint
+ *
+ * Tests:
+ * - POST /api/problems/[id]/practice - Find or create practice session
+ *
+ * Coverage:
+ * - Authentication checks
+ * - Section membership validation
+ * - Problem existence validation
+ * - Reuse existing completed sessions
+ * - Create new session when none exists
+ * - Add student to session
+ * - Error handling
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { POST } from '../route';
+import { createStorage } from '@/server/persistence';
+import * as SessionService from '@/server/services/session-service';
+import { requireAuth } from '@/server/auth/api-helpers';
+import type { User } from '@/server/auth/types';
+import { RBACService } from '@/server/auth/rbac';
+import { rateLimit } from '@/server/rate-limit';
+
+// Mock dependencies
+jest.mock('@/server/persistence');
+jest.mock('@/server/services/session-service');
+jest.mock('@/server/rate-limit');
+jest.mock('@/server/auth/api-helpers', () => ({
+  requireAuth: jest.fn(),
+  getNamespaceContext: jest.fn((req: any, user: any) => user.namespaceId || 'default'),
+}));
+
+const mockCreateStorage = createStorage as jest.MockedFunction<typeof createStorage>;
+const mockRequireAuth = requireAuth as jest.MockedFunction<typeof requireAuth>;
+const mockRateLimit = rateLimit as jest.MockedFunction<typeof rateLimit>;
+
+// Helper to create auth context
+function createAuthContext(user: User) {
+  return {
+    user,
+    accessToken: 'test-access-token',
+    rbac: new RBACService(),
+  };
+}
+
+describe('POST /api/problems/[id]/practice', () => {
+  const mockUser: User = {
+    id: 'student-1',
+    email: 'student@test.com',
+    displayName: 'Test Student',
+    role: 'student' as const,
+    namespaceId: 'default',
+    createdAt: new Date('2025-01-01'),
+  };
+
+  const mockProblem = {
+    id: 'problem-123',
+    title: 'Test Problem',
+    description: 'Test description',
+    starterCode: 'def solution():\n    pass',
+    testCases: [],
+    authorId: 'instructor-1',
+    classId: 'class-1',
+    namespaceId: 'default',
+    tags: [],
+    createdAt: new Date('2025-01-01'),
+    updatedAt: new Date('2025-01-01'),
+  };
+
+  const mockSection = {
+    id: 'section-1',
+    classId: 'class-1',
+    name: 'Section A',
+    namespaceId: 'default',
+    joinCode: 'ABC123',
+    active: true,
+    createdAt: new Date('2025-01-01'),
+  };
+
+  const mockMembership = {
+    id: 'membership-1',
+    userId: 'student-1',
+    sectionId: 'section-1',
+    role: 'student' as const,
+    createdAt: new Date('2025-01-01'),
+  };
+
+  const mockCompletedSession = {
+    id: 'session-123',
+    namespaceId: 'default',
+    problem: mockProblem,
+    students: new Map(),
+    createdAt: new Date('2025-01-01'),
+    lastActivity: new Date('2025-01-01'),
+    creatorId: 'instructor-1',
+    participants: [],
+    status: 'completed' as const,
+    sectionId: 'section-1',
+    sectionName: 'Section A',
+    endedAt: new Date('2025-01-01'),
+  };
+
+  let mockUserStorage: any;
+  let mockServiceStorage: any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    // Default: rate limit passes (returns null)
+    mockRateLimit.mockResolvedValue(null);
+
+    // Setup mock storages
+    mockUserStorage = {
+      problems: {
+        getById: jest.fn().mockResolvedValue(mockProblem),
+      },
+      memberships: {
+        getMembership: jest.fn().mockResolvedValue(mockMembership),
+      },
+    };
+
+    mockServiceStorage = {
+      sessions: {
+        listAllSessions: jest.fn().mockResolvedValue([]),
+        getSession: jest.fn(),
+      },
+    };
+
+    // First call returns user storage, subsequent calls return service storage
+    mockCreateStorage.mockImplementation((token: string) => {
+      if (token === 'test-access-token') {
+        return Promise.resolve(mockUserStorage as any);
+      }
+      return Promise.resolve(mockServiceStorage as any);
+    });
+  });
+
+  it('should return 401 when not authenticated', async () => {
+    mockRequireAuth.mockResolvedValue(
+      NextResponse.json({ error: 'Not authenticated' }, { status: 401 })
+    );
+
+    const request = new NextRequest('http://localhost/api/problems/problem-123/practice', {
+      method: 'POST',
+      body: JSON.stringify({ sectionId: 'section-1' }),
+    });
+    const params = { params: Promise.resolve({ id: 'problem-123' }) };
+
+    const response = await POST(request, params);
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data.error).toBe('Not authenticated');
+  });
+
+  it('should return 400 when sectionId is missing', async () => {
+    mockRequireAuth.mockResolvedValue(createAuthContext(mockUser));
+
+    const request = new NextRequest('http://localhost/api/problems/problem-123/practice', {
+      method: 'POST',
+      body: JSON.stringify({}),
+    });
+    const params = { params: Promise.resolve({ id: 'problem-123' }) };
+
+    const response = await POST(request, params);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error).toBe('sectionId is required');
+  });
+
+  it('should return 404 when problem not found', async () => {
+    mockRequireAuth.mockResolvedValue(createAuthContext(mockUser));
+
+    mockUserStorage.problems.getById.mockResolvedValue(null);
+
+    const request = new NextRequest('http://localhost/api/problems/problem-123/practice', {
+      method: 'POST',
+      body: JSON.stringify({ sectionId: 'section-1' }),
+    });
+    const params = { params: Promise.resolve({ id: 'problem-123' }) };
+
+    const response = await POST(request, params);
+    const data = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(data.error).toBe('Problem not found');
+  });
+
+  it('should return 403 when user is not a member of the section', async () => {
+    mockRequireAuth.mockResolvedValue(createAuthContext(mockUser));
+
+    mockUserStorage.memberships.getMembership.mockResolvedValue(null);
+
+    const request = new NextRequest('http://localhost/api/problems/problem-123/practice', {
+      method: 'POST',
+      body: JSON.stringify({ sectionId: 'section-1' }),
+    });
+    const params = { params: Promise.resolve({ id: 'problem-123' }) };
+
+    const response = await POST(request, params);
+    const data = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(data.error).toBe('Not a member of this section');
+  });
+
+  it('should reuse existing completed session with same problem', async () => {
+    mockRequireAuth.mockResolvedValue(createAuthContext(mockUser));
+
+    // Mock existing completed session
+    mockServiceStorage.sessions.listAllSessions.mockResolvedValue([mockCompletedSession]);
+
+    // Mock addStudent
+    const mockStudent = {
+      userId: 'student-1',
+      name: 'Test Student',
+      code: mockProblem.starterCode,
+      lastUpdate: new Date(),
+    };
+    jest.spyOn(SessionService, 'addStudent').mockResolvedValue(mockStudent);
+
+    const request = new NextRequest('http://localhost/api/problems/problem-123/practice', {
+      method: 'POST',
+      body: JSON.stringify({ sectionId: 'section-1' }),
+    });
+    const params = { params: Promise.resolve({ id: 'problem-123' }) };
+
+    const response = await POST(request, params);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.sessionId).toBe('session-123');
+
+    // Should NOT create a new session
+    expect(SessionService.createSessionWithProblem).not.toHaveBeenCalled();
+    expect(SessionService.endSession).not.toHaveBeenCalled();
+
+    // Should add student to existing session
+    expect(SessionService.addStudent).toHaveBeenCalledWith(
+      mockServiceStorage,
+      mockCompletedSession,
+      'student-1',
+      'Test Student'
+    );
+  });
+
+  it('should create new session when no completed session exists', async () => {
+    mockRequireAuth.mockResolvedValue(createAuthContext(mockUser));
+
+    // No existing sessions
+    mockServiceStorage.sessions.listAllSessions.mockResolvedValue([]);
+
+    // Mock session creation
+    const newSession = { ...mockCompletedSession, status: 'active' as const };
+    jest.spyOn(SessionService, 'createSessionWithProblem').mockResolvedValue(newSession);
+    jest.spyOn(SessionService, 'endSession').mockResolvedValue(undefined);
+
+    // Mock getSession to return completed session after ending
+    const completedSession = { ...newSession, status: 'completed' as const };
+    mockServiceStorage.sessions.getSession.mockResolvedValue(completedSession);
+
+    // Mock addStudent
+    const mockStudent = {
+      userId: 'student-1',
+      name: 'Test Student',
+      code: mockProblem.starterCode,
+      lastUpdate: new Date(),
+    };
+    jest.spyOn(SessionService, 'addStudent').mockResolvedValue(mockStudent);
+
+    const request = new NextRequest('http://localhost/api/problems/problem-123/practice', {
+      method: 'POST',
+      body: JSON.stringify({ sectionId: 'section-1' }),
+    });
+    const params = { params: Promise.resolve({ id: 'problem-123' }) };
+
+    const response = await POST(request, params);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.sessionId).toBe('session-123');
+
+    // Should create session, end it, and add student
+    expect(SessionService.createSessionWithProblem).toHaveBeenCalledWith(
+      mockServiceStorage,
+      'student-1',
+      'section-1',
+      'default',
+      'problem-123'
+    );
+    expect(SessionService.endSession).toHaveBeenCalledWith(mockServiceStorage, 'session-123');
+    expect(SessionService.addStudent).toHaveBeenCalledWith(
+      mockServiceStorage,
+      completedSession,
+      'student-1',
+      'Test Student'
+    );
+  });
+
+  it('should find correct session when multiple completed sessions exist', async () => {
+    mockRequireAuth.mockResolvedValue(createAuthContext(mockUser));
+
+    // Mock multiple completed sessions with different problems
+    const otherSession = {
+      ...mockCompletedSession,
+      id: 'session-other',
+      problem: { ...mockProblem, id: 'other-problem' },
+    };
+    mockServiceStorage.sessions.listAllSessions.mockResolvedValue([
+      otherSession,
+      mockCompletedSession,
+    ]);
+
+    // Mock addStudent
+    const mockStudent = {
+      userId: 'student-1',
+      name: 'Test Student',
+      code: mockProblem.starterCode,
+      lastUpdate: new Date(),
+    };
+    jest.spyOn(SessionService, 'addStudent').mockResolvedValue(mockStudent);
+
+    const request = new NextRequest('http://localhost/api/problems/problem-123/practice', {
+      method: 'POST',
+      body: JSON.stringify({ sectionId: 'section-1' }),
+    });
+    const params = { params: Promise.resolve({ id: 'problem-123' }) };
+
+    const response = await POST(request, params);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.sessionId).toBe('session-123'); // Should find the matching session
+
+    // Should use the correct session
+    expect(SessionService.addStudent).toHaveBeenCalledWith(
+      mockServiceStorage,
+      mockCompletedSession,
+      'student-1',
+      'Test Student'
+    );
+  });
+
+  it('should use displayName when available', async () => {
+    mockRequireAuth.mockResolvedValue(createAuthContext(mockUser));
+
+    mockServiceStorage.sessions.listAllSessions.mockResolvedValue([mockCompletedSession]);
+
+    const mockStudent = {
+      userId: 'student-1',
+      name: 'Test Student',
+      code: mockProblem.starterCode,
+      lastUpdate: new Date(),
+    };
+    jest.spyOn(SessionService, 'addStudent').mockResolvedValue(mockStudent);
+
+    const request = new NextRequest('http://localhost/api/problems/problem-123/practice', {
+      method: 'POST',
+      body: JSON.stringify({ sectionId: 'section-1' }),
+    });
+    const params = { params: Promise.resolve({ id: 'problem-123' }) };
+
+    await POST(request, params);
+
+    expect(SessionService.addStudent).toHaveBeenCalledWith(
+      mockServiceStorage,
+      mockCompletedSession,
+      'student-1',
+      'Test Student' // displayName
+    );
+  });
+
+  it('should fall back to email when displayName is not available', async () => {
+    const userWithoutDisplayName = { ...mockUser, displayName: undefined };
+    mockRequireAuth.mockResolvedValue(createAuthContext(userWithoutDisplayName));
+
+    mockServiceStorage.sessions.listAllSessions.mockResolvedValue([mockCompletedSession]);
+
+    const mockStudent = {
+      userId: 'student-1',
+      name: 'student@test.com',
+      code: mockProblem.starterCode,
+      lastUpdate: new Date(),
+    };
+    jest.spyOn(SessionService, 'addStudent').mockResolvedValue(mockStudent);
+
+    const request = new NextRequest('http://localhost/api/problems/problem-123/practice', {
+      method: 'POST',
+      body: JSON.stringify({ sectionId: 'section-1' }),
+    });
+    const params = { params: Promise.resolve({ id: 'problem-123' }) };
+
+    await POST(request, params);
+
+    expect(SessionService.addStudent).toHaveBeenCalledWith(
+      mockServiceStorage,
+      mockCompletedSession,
+      'student-1',
+      'student@test.com' // email fallback
+    );
+  });
+
+  it('should fall back to "Student" when neither displayName nor email are available', async () => {
+    const userWithoutName = { ...mockUser, displayName: undefined, email: '' };
+    mockRequireAuth.mockResolvedValue(createAuthContext(userWithoutName));
+
+    mockServiceStorage.sessions.listAllSessions.mockResolvedValue([mockCompletedSession]);
+
+    const mockStudent = {
+      userId: 'student-1',
+      name: 'Student',
+      code: mockProblem.starterCode,
+      lastUpdate: new Date(),
+    };
+    jest.spyOn(SessionService, 'addStudent').mockResolvedValue(mockStudent);
+
+    const request = new NextRequest('http://localhost/api/problems/problem-123/practice', {
+      method: 'POST',
+      body: JSON.stringify({ sectionId: 'section-1' }),
+    });
+    const params = { params: Promise.resolve({ id: 'problem-123' }) };
+
+    await POST(request, params);
+
+    expect(SessionService.addStudent).toHaveBeenCalledWith(
+      mockServiceStorage,
+      mockCompletedSession,
+      'student-1',
+      'Student' // final fallback
+    );
+  });
+
+  it('should handle errors when creating session fails', async () => {
+    mockRequireAuth.mockResolvedValue(createAuthContext(mockUser));
+
+    mockServiceStorage.sessions.listAllSessions.mockResolvedValue([]);
+
+    jest.spyOn(SessionService, 'createSessionWithProblem').mockRejectedValue(
+      new Error('Failed to create session')
+    );
+
+    const request = new NextRequest('http://localhost/api/problems/problem-123/practice', {
+      method: 'POST',
+      body: JSON.stringify({ sectionId: 'section-1' }),
+    });
+    const params = { params: Promise.resolve({ id: 'problem-123' }) };
+
+    const response = await POST(request, params);
+    const data = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(data.error).toBe('Failed to create session');
+  });
+
+  it('should handle errors when adding student fails', async () => {
+    mockRequireAuth.mockResolvedValue(createAuthContext(mockUser));
+
+    mockServiceStorage.sessions.listAllSessions.mockResolvedValue([mockCompletedSession]);
+
+    jest.spyOn(SessionService, 'addStudent').mockRejectedValue(
+      new Error('Failed to add student')
+    );
+
+    const request = new NextRequest('http://localhost/api/problems/problem-123/practice', {
+      method: 'POST',
+      body: JSON.stringify({ sectionId: 'section-1' }),
+    });
+    const params = { params: Promise.resolve({ id: 'problem-123' }) };
+
+    const response = await POST(request, params);
+    const data = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(data.error).toBe('Failed to add student');
+  });
+
+  it('should respect rate limiting', async () => {
+    mockRequireAuth.mockResolvedValue(createAuthContext(mockUser));
+
+    const rateLimitResponse = NextResponse.json(
+      { error: 'Rate limit exceeded' },
+      { status: 429 }
+    );
+    mockRateLimit.mockResolvedValue(rateLimitResponse);
+
+    const request = new NextRequest('http://localhost/api/problems/problem-123/practice', {
+      method: 'POST',
+      body: JSON.stringify({ sectionId: 'section-1' }),
+    });
+    const params = { params: Promise.resolve({ id: 'problem-123' }) };
+
+    const response = await POST(request, params);
+
+    expect(response).toBe(rateLimitResponse);
+    expect(mockRateLimit).toHaveBeenCalledWith('write', request, 'student-1');
+  });
+
+  it('should use service role storage for session operations', async () => {
+    mockRequireAuth.mockResolvedValue(createAuthContext(mockUser));
+
+    mockServiceStorage.sessions.listAllSessions.mockResolvedValue([]);
+
+    const newSession = { ...mockCompletedSession, status: 'active' as const };
+    jest.spyOn(SessionService, 'createSessionWithProblem').mockResolvedValue(newSession);
+    jest.spyOn(SessionService, 'endSession').mockResolvedValue(undefined);
+
+    const completedSession = { ...newSession, status: 'completed' as const };
+    mockServiceStorage.sessions.getSession.mockResolvedValue(completedSession);
+
+    const mockStudent = {
+      userId: 'student-1',
+      name: 'Test Student',
+      code: mockProblem.starterCode,
+      lastUpdate: new Date(),
+    };
+    jest.spyOn(SessionService, 'addStudent').mockResolvedValue(mockStudent);
+
+    const request = new NextRequest('http://localhost/api/problems/problem-123/practice', {
+      method: 'POST',
+      body: JSON.stringify({ sectionId: 'section-1' }),
+    });
+    const params = { params: Promise.resolve({ id: 'problem-123' }) };
+
+    await POST(request, params);
+
+    // Verify service storage was used for session operations
+    expect(mockServiceStorage.sessions.listAllSessions).toHaveBeenCalledWith({
+      sectionId: 'section-1',
+      active: false,
+      namespaceId: 'default',
+    });
+    expect(SessionService.createSessionWithProblem).toHaveBeenCalledWith(
+      mockServiceStorage,
+      expect.any(String),
+      expect.any(String),
+      expect.any(String),
+      expect.any(String)
+    );
+  });
+});

--- a/src/app/api/problems/[id]/practice/route.ts
+++ b/src/app/api/problems/[id]/practice/route.ts
@@ -1,0 +1,137 @@
+/**
+ * Practice mode API endpoint
+ *
+ * POST /api/problems/[id]/practice - Find or create a completed session for practice
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { requireAuth, getNamespaceContext } from '@/server/auth/api-helpers';
+import { createStorage } from '@/server/persistence';
+import { SERVICE_ROLE_MARKER } from '@/server/supabase/client';
+import * as SessionService from '@/server/services/session-service';
+import { rateLimit } from '@/server/rate-limit';
+
+type Params = {
+  params: Promise<{
+    id: string;
+  }>;
+};
+
+/**
+ * POST /api/problems/[id]/practice
+ *
+ * Find or create a completed session for a problem in a section.
+ * This enables students to practice problems without affecting active sessions.
+ *
+ * Request body: { sectionId: string }
+ * Response: { sessionId: string }
+ */
+export async function POST(
+  request: NextRequest,
+  { params }: Params
+) {
+  try {
+    const { id: problemId } = await params;
+
+    // Authenticate user
+    const auth = await requireAuth(request);
+    if (auth instanceof NextResponse) {
+      return auth; // Return 401 error response
+    }
+
+    const { user, accessToken } = auth;
+
+    // Rate limit by user ID (write operation - creates session)
+    const limited = await rateLimit('write', request, user.id);
+    if (limited) return limited;
+
+    const namespaceId = getNamespaceContext(request, user);
+    if (!namespaceId) {
+      return NextResponse.json(
+        { error: 'Namespace context required' },
+        { status: 400 }
+      );
+    }
+
+    // Parse request body
+    const body = await request.json();
+    const { sectionId } = body;
+
+    if (!sectionId) {
+      return NextResponse.json(
+        { error: 'sectionId is required' },
+        { status: 400 }
+      );
+    }
+
+    // Create storage with user's access token for validation
+    const userStorage = await createStorage(accessToken);
+
+    // Validate problem exists
+    const problem = await userStorage.problems.getById(problemId, namespaceId);
+    if (!problem) {
+      return NextResponse.json(
+        { error: 'Problem not found' },
+        { status: 404 }
+      );
+    }
+
+    // Validate section membership
+    const membership = await userStorage.memberships.getMembership(user.id, sectionId);
+    if (!membership) {
+      return NextResponse.json(
+        { error: 'Not a member of this section' },
+        { status: 403 }
+      );
+    }
+
+    // Find existing practice session
+    // Note: Use service role for broader query permissions
+    const serviceStorage = await createStorage(SERVICE_ROLE_MARKER);
+    const completedSessions = await serviceStorage.sessions.listAllSessions({
+      sectionId,
+      active: false,
+      namespaceId,
+    });
+
+    // Find a completed session that uses this problem
+    let session = completedSessions.find(s => s.problem?.id === problemId);
+
+    // If no session found, create one
+    if (!session) {
+      // Create session with the problem
+      session = await SessionService.createSessionWithProblem(
+        serviceStorage,
+        user.id,
+        sectionId,
+        namespaceId,
+        problemId
+      );
+
+      // End the session immediately (mark as completed)
+      await SessionService.endSession(serviceStorage, session.id);
+
+      // Reload session to get updated status
+      const updatedSession = await serviceStorage.sessions.getSession(session.id);
+      if (updatedSession) {
+        session = updatedSession;
+      }
+    }
+
+    // Add student to session
+    await SessionService.addStudent(
+      serviceStorage,
+      session,
+      user.id,
+      user.displayName || user.email || 'Student'
+    );
+
+    return NextResponse.json({ sessionId: session.id });
+  } catch (error: any) {
+    console.error('[API] Practice mode error:', error);
+    return NextResponse.json(
+      { error: error.message || 'Failed to create practice session' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/problems/[id]/practice/route.ts
+++ b/src/app/api/problems/[id]/practice/route.ts
@@ -130,7 +130,7 @@ export async function POST(
   } catch (error: any) {
     console.error('[API] Practice mode error:', error);
     return NextResponse.json(
-      { error: error.message || 'Failed to create practice session' },
+      { error: 'Failed to create practice session' },
       { status: 500 }
     );
   }

--- a/src/app/api/sessions/[id]/code/route.ts
+++ b/src/app/api/sessions/[id]/code/route.ts
@@ -98,6 +98,9 @@ export async function POST(
       );
     }
 
+    // Note: Code saving is allowed in completed sessions to support practice mode
+    // where students can save and run code without affecting the original session state.
+
     // Verify student exists in session
     if (!session.students.has(studentId)) {
       return NextResponse.json(

--- a/src/app/api/sessions/[id]/join/__tests__/route.test.ts
+++ b/src/app/api/sessions/[id]/join/__tests__/route.test.ts
@@ -210,7 +210,7 @@ describe('POST /api/sessions/[id]/join', () => {
     expect(data.error).toBe('Session not found');
   });
 
-  it('returns 400 when session is completed', async () => {
+  it('allows joining completed sessions for practice mode', async () => {
     mockGetAuthenticatedUserWithToken.mockResolvedValue({ user: mockUser, accessToken: 'test-token' });
     mockStorage.sessions.getSession.mockResolvedValue({
       ...mockSession,
@@ -226,8 +226,16 @@ describe('POST /api/sessions/[id]/join', () => {
     const response = await POST(request, { params });
     const data = await response.json();
 
-    expect(response.status).toBe(400);
-    expect(data.error).toBe('This session has ended and cannot be joined');
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(data.student.id).toBe('user-1');
+    expect(data.student.name).toBe('Alice');
+    expect(SessionService.addStudent).toHaveBeenCalledWith(
+      mockStorage,
+      expect.objectContaining({ status: 'completed' }),
+      'user-1',
+      'Alice'
+    );
   });
 
   it('returns 500 when service fails', async () => {

--- a/src/app/api/sessions/[id]/join/route.ts
+++ b/src/app/api/sessions/[id]/join/route.ts
@@ -88,14 +88,6 @@ export async function POST(
       );
     }
 
-    // Check if session is completed
-    if (session.status === 'completed') {
-      return NextResponse.json(
-        { error: 'This session has ended and cannot be joined' },
-        { status: 400 }
-      );
-    }
-
     // Add student via service (handles starter code, participants, persistence)
     const student = await SessionService.addStudent(storage, session, user.id, name);
 


### PR DESCRIPTION
## Summary
- Students can practice on problems asynchronously by clicking a "Practice" button on public problem pages
- System auto-creates completed sessions as storage containers for practice
- Reuses existing practice mode execution and student editor UI
- Instructor-shared problems now support self-paced learning

## Changes
- **Backend:**
  - Removed guard preventing joins to completed sessions (`/api/sessions/[id]/join`)
  - Added `/api/problems/[id]/practice` endpoint to find/create practice sessions
  - Added INPUT_ECHO_PREAMBLE to ephemeral execution for stdin echo consistency
  - Fixed error message leakage in practice route (generic errors instead of `error.message`)
  - Fixed incorrect `executionTime` reporting on timeout (use actual elapsed time)

- **Frontend:**
  - Added `StudentActions` component with Practice button to public problem pages
  - Section auto-selection (one section) or picker (multiple sections)
  - Integrated with existing student editor for code saving and execution
  - Fixed stale session data causing session-ended notification to appear on replacement sessions (`student/page.tsx`)

- **Tests:**
  - Comprehensive unit test coverage for practice endpoint and StudentActions component
  - Updated join route tests for completed session behavior

## Test plan
- [x] Unit tests pass
- [x] TypeScript compilation succeeds
- [x] Linter passes
- [ ] E2E session-lifecycle test (currently failing — `coding-tool-st3z`)

Beads: coding-tool-rwiv, coding-tool-rwiv.1, coding-tool-rwiv.2, coding-tool-rwiv.3, coding-tool-ivfq, coding-tool-cggm, coding-tool-0h84

Generated with Claude Code