### PR TITLE
docs(claude): correct testing section (real helper names + real-DB integration tests)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,13 @@ Jest projects (see `jest.config.js`):
 - **server**: `src/server/**/__tests__/**/*.test.ts`, `src/app/api/**/__tests__/**/*.test.ts`
 - **client**: `src/app/**/__tests__/**/*.test.tsx`, `src/hooks/**/__tests__/**/*.test.ts`
 
-Test utilities: `src/server/__tests__/test-utils/` (server mocks/helpers), `src/app/api/__tests__/test-helpers.ts` (`createMockAuth()`). Use repository mocks to isolate business logic from persistence.
+Test utilities: `src/server/__tests__/test-utils/` (server mocks/helpers) and `src/app/api/__tests__/test-helpers.ts` (`mockRequirePermission` / `setupRequirePermissionMock`).
+
+Three test styles, in order of preference (unit > integration > e2e):
+
+- **Mocked unit/route tests** (the default; run in the `server` / `client` Jest projects). Mock persistence to isolate business logic — e.g. the per-file `createAuthContext` + `jest.mock('@/server/auth/api-helpers')` pattern in `src/app/api/problems/__tests__/route.test.ts`.
+- **Real-DB integration tests** — run against a live local Supabase with a real `createClient`, gated by `describeIfSupabase` (`describe` when `SUPABASE_SECRET_KEY` is set, else `describe.skip`, so they skip cleanly without credentials). These run inside the default `server` project. Use this when behavior depends on real SQL/RLS (e.g. ownership/permission enforcement). Pattern: `src/server/auth/__tests__/supabase-integration.test.ts`. (A separate `*.integration.test.ts` suffix — excluded from default runs via `testPathIgnorePatterns`, run by `npm run test:integration:sandbox` — is reserved for the Python sandbox.)
+- **E2E** — Playwright (`npm run test:e2e`), for frontend/full-stack behavior.
 
 ## Development Guidelines
 


### PR DESCRIPTION
## What

Fixes two inaccuracies in the CLAUDE.md **Testing Rules** section that were actively misleading agents:

- Referenced a non-existent `createMockAuth()`. The file (`src/app/api/__tests__/test-helpers.ts`) actually exports `mockRequirePermission` / `setupRequirePermissionMock`.
- "Use repository mocks to isolate business logic from persistence" read as if Jest *always* mocks the DB — hiding the real-DB integration pattern entirely.

Rewrites the section into an explicit three-style breakdown:
1. **Mocked unit/route tests** (default) — points at the real per-file `createAuthContext` + `jest.mock('@/server/auth/api-helpers')` pattern.
2. **Real-DB integration tests** — real `createClient` against local Supabase, gated by `describeIfSupabase` / `SUPABASE_SECRET_KEY`, running in the default `server` project (exemplar: `supabase-integration.test.ts`). Clarifies the `*.integration.test.ts` suffix is reserved for the Python sandbox suite.
3. **E2E** — Playwright.

## Why

This is the documentation gap that led a plan reviewer (and Claude) to wrongly assume persistence is always mocked, nearly mis-scoping a feature's ownership/RLS test. CLAUDE.md is loaded into every session, so a wrong line here propagates silently to every agent.

## Note

Originally committed onto `feature/devcontainer-psql` but landed ~6 min after that PR (#73) merged, so it stranded on the merged branch. This re-lands it via cherry-pick onto current `main`. Docs-only change; no code, no tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)