### PR TITLE
fix(auth): make supabase-integration real-DB suite pass when run

### DIFF
--- a/src/server/auth/__tests__/supabase-integration.test.ts
+++ b/src/server/auth/__tests__/supabase-integration.test.ts
@@ -16,6 +16,32 @@ import { createClient, SupabaseClient } from '@supabase/supabase-js';
 import { SupabaseAuthProvider } from '../supabase-provider';
 import { UserRole } from '../types';
 
+// setupTests.ts globally mocks the server Supabase client for unit tests. This
+// is a real-DB integration suite, so use the actual client: the provider's
+// internal user repository (getUser/updateUser) must hit the live database, not
+// the in-memory mock.
+jest.mock('@/server/supabase/client', () =>
+  jest.requireActual('@/server/supabase/client')
+);
+
+// authenticateWithPassword / signOut build a server client via next/headers
+// cookies(), which throws outside a request scope. Provide an in-memory cookie
+// store so the auth session round-trips during the sign-in tests.
+jest.mock('next/headers', () => {
+  const store = new Map<string, string>();
+  return {
+    cookies: async () => ({
+      get: (name: string) => {
+        const value = store.get(name);
+        return value === undefined ? undefined : { name, value };
+      },
+      set: (name: string, value: string) => {
+        store.set(name, value);
+      },
+    }),
+  };
+});
+
 // Skip these tests if Supabase credentials are not available
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
 const serviceRoleKey = process.env.SUPABASE_SECRET_KEY;
@@ -23,11 +49,15 @@ const hasSupabaseCredentials = Boolean(supabaseUrl && serviceRoleKey);
 
 const describeIfSupabase = hasSupabaseCredentials ? describe : describe.skip;
 
+// Namespace the signUp tests reference. Created in beforeAll so the suite is
+// self-contained and does not depend on seed data (the seed uses 'test-school').
+const TEST_NAMESPACE_ID = 'default';
+
 describeIfSupabase('Supabase Auth Integration', () => {
   let supabase: SupabaseClient;
   let authProvider: SupabaseAuthProvider;
 
-  beforeAll(() => {
+  beforeAll(async () => {
     supabase = createClient(supabaseUrl!, serviceRoleKey!, {
       auth: {
         autoRefreshToken: false,
@@ -36,6 +66,23 @@ describeIfSupabase('Supabase Auth Integration', () => {
     });
 
     authProvider = new SupabaseAuthProvider();
+
+    // Ensure the namespace referenced by signUp exists (user_profiles.namespace_id
+    // has a FK to namespaces). Idempotent so repeated local runs don't fail.
+    const { error } = await supabase
+      .from('namespaces')
+      .upsert(
+        { id: TEST_NAMESPACE_ID, display_name: 'Default (integration test)' },
+        { onConflict: 'id' }
+      );
+    if (error) {
+      throw new Error(`Failed to create test namespace: ${error.message}`);
+    }
+  });
+
+  afterAll(async () => {
+    // Remove the test namespace. ON DELETE CASCADE clears any lingering profiles.
+    await supabase.from('namespaces').delete().eq('id', TEST_NAMESPACE_ID);
   });
 
   afterEach(async () => {


### PR DESCRIPTION
## Summary
The `supabase-integration.test.ts` real-DB suite is gated on `SUPABASE_SECRET_KEY` (green-by-skip in CI) and failed completely — 15/18 — when actually run against a local Supabase. Three independent test-setup issues caused the failures; all are fixed on the test side, leaving the FK constraint and production code untouched.

## Changes
All in `src/server/auth/__tests__/supabase-integration.test.ts`:
- **Namespace FK:** signUp referenced namespace `'default'`, which `user_profiles.namespace_id` requires but the seed never creates (seed uses `'test-school'`). The suite now creates and tears down a dedicated `'default'` namespace, so it's self-contained rather than seed-dependent.
- **Globally-mocked client:** `setupTests.ts` mocks `getSupabaseClient` for unit tests, so the provider's internal user repository (`getUser`/`updateUser`) hit an empty in-memory mock and returned `null`. This suite now uses the real client.
- **`cookies()` outside request scope:** `authenticateWithPassword`/`signOut` build a server client via `next/headers` `cookies()`, which throws in Jest. An in-memory cookie store lets the auth session round-trip.

## Test plan
- [x] `supabase-integration` suite: 18/18 pass against fresh local Supabase
- [x] Full `server` Jest project: 1853/1853 pass (global mock still works for other files)
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` — 0 errors

Beads: coding-ruk

Generated with Claude Code