### PR TITLE
fix(skills): correct implementer commit model + sync drift from agent-workflow/eval

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# SessionStart hook: detect a stale feature branch in the main checkout and warn.
+#
+# When /clear runs, the session's working directory doesn't change. If a previous
+# agent left the main checkout on a feature branch, the new session inherits that
+# state. This hook warns the agent so it can return to main — unless the user
+# explicitly directs it to work on the current branch.
+#
+# The in-worktree case is handled deterministically by mark-stale-worktree.sh +
+# block-stale-worktree.sh, so only the stale-branch-in-main-checkout case needs a
+# text warning here.
+
+set -euo pipefail
+
+# git-common-dir is always the .git of the main worktree; git-dir differs inside
+# a linked worktree. If they differ, we're in a worktree.
+git_common=$(git rev-parse --git-common-dir 2>/dev/null || echo "")
+git_dir=$(git rev-parse --git-dir 2>/dev/null || echo "")
+current_branch=$(git branch --show-current 2>/dev/null || echo "")
+
+in_worktree=false
+if [ -n "$git_common" ] && [ -n "$git_dir" ] && [ "$git_common" != "$git_dir" ]; then
+  in_worktree=true
+fi
+
+if [ "$in_worktree" = false ] && [ -n "$current_branch" ] && [ "$current_branch" != "main" ]; then
+  cat <<EOF
+CRITICAL FIRST INSTRUCTION: You are on branch '$current_branch' from a previous session.
+
+Before doing ANYTHING else, run: git checkout main
+Continuing on a stale branch will lead to wrong diffs and lost work.
+Do NOT respond to the user's message until you have returned to main (unless the user explicitly asks you to work on this branch).
+
+EOF
+fi
+
+# Inject up-to-date bd workflow guidance from the installed bd version.
+# Project-specific guidance lives in CLAUDE.md (auto-loaded by Claude Code).
+if command -v bd >/dev/null 2>&1; then
+  bd prime 2>/dev/null || true
+fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -9,7 +9,7 @@
           },
           {
             "type": "command",
-            "command": "bd prime 2>/dev/null || true"
+            "command": "bash .claude/hooks/session-start.sh"
           }
         ]
       }

--- a/.claude/skills/coordinator/SKILL.md
+++ b/.claude/skills/coordinator/SKILL.md
@@ -105,7 +105,7 @@ Read the task description: bd show <task-id> --json
 
 #### c. Handle Result
 
-The implementer's final output is a structured summary (Phase 5). Only read that summary — ignore intermediate tool output from the subagent. The Agent tool's result metadata exposes `worktree_path` and `branch` for integration.
+The implementer's final output is a structured summary (Phase 6). Only read that summary — ignore intermediate tool output from the subagent. The Agent tool's result metadata exposes `worktree_path` and `branch` for integration.
 
 **On implementer FAILURE or STALL** (timeout, crash, incomplete summary): don't silently drop the work. Choose one — retry with continuation, finish the task inline, or ask the user how to proceed.
 
@@ -158,17 +158,17 @@ Triage the "Concerns" section. Filing follow-ups mid-implementation is fine — 
 
 ### 3. Pre-PR Review
 
-Reviews are **optional** for small, isolated changes (single-file fixes, typo corrections, config tweaks). For anything of any complexity — multi-file changes, new features, behavioral changes, refactors — reviews are **required**. The same condition gates the /simplify pass in 2a — skip both together for trivial changes.
+Reviews are **optional** for small, isolated changes (single-file fixes, typo corrections, config tweaks). For anything of any complexity — multi-file changes, new features, behavioral changes, refactors — reviews are **required**. The same condition gates the /simplify pass in 3a — skip both together for trivial changes.
 
-#### 2a. Cleanup pass (/simplify)
+#### 3a. Cleanup pass (/simplify)
 
 After all tasks are merged into the feature branch, invoke the Claude Code built-in `/simplify` skill via the Skill tool (`skill: "simplify"`). It spawns 3 parallel agents (reuse / quality / efficiency) over the changed files and **auto-commits** cleanup fixes directly to the feature branch.
 
 `/simplify` is bundled with Claude Code — there is no repo-local SKILL.md for it. Do not try to read it from `.claude/skills/`.
 
-Rationale: running the cleanup pass before the specialized reviewers means they assess post-cleanup code instead of wasting cycles on cruft `/simplify` already removed. Auto-fix is safe here — the 3 specialized reviewers in 2b inspect the post-cleanup diff, and the user inspects the final PR diff before merge.
+Rationale: running the cleanup pass before the specialized reviewers means they assess post-cleanup code instead of wasting cycles on cruft `/simplify` already removed. Auto-fix is safe here — the 3 specialized reviewers in 3b inspect the post-cleanup diff, and the user inspects the final PR diff before merge.
 
-#### 2b. Specialized reviews
+#### 3b. Specialized reviews
 
 After `/simplify` has committed its cleanup, run 3 specialized reviews **in parallel** using the Task tool. Each reviewer enters the coordinator's existing worktree (do NOT create a new worktree):
 
@@ -230,7 +230,7 @@ If the epic has e2e acceptance tests, run them here targeting the specific spec 
 
 **Skip the test-runner entirely** only for genuinely gate-free changes (pure docs/config). **Do NOT create PR if the test-runner reports FAIL.** Fix locally first (spawn implementer if non-trivial).
 
-### 3. Create PR, Monitor CI, and Hand Off
+### 4. Create PR, Monitor CI, and Hand Off
 
 **PR description guidelines:**
 

--- a/.claude/skills/implementer/SKILL.md
+++ b/.claude/skills/implementer/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: implementer
-description: Pure development workflow with test-first development and coverage review. Used by coordinator as a subagent. Never manages beads issues or commits.
+description: Pure development workflow with test-first development and coverage review. Used by coordinator as a subagent. Commits to its own worktree branch, but never pushes, manages beads issues, or opens PRs.
 ---
 
 # Implementer
 
 Follow these phases **in strict order**. Do not skip phases. Do not proceed until the current phase's gate is satisfied.
 
-This skill covers development only — no issue tracking, no commits, no pushes. The coordinator handles those.
+This skill covers development through committing to your own worktree branch — no issue tracking, no pushing, no PRs. The coordinator handles those: it integrates your branch by rebasing your commits onto the feature branch (see Phase 5). Your work only survives integration if it is **committed** — uncommitted changes are discarded when the coordinator removes your worktree.
 
 ## Principles
 
@@ -64,7 +64,22 @@ Verify all planned test cases are implemented. Then check for meaningful gaps: c
 
 **Gate:** All planned test cases implemented. No meaningful coverage gaps, or gaps documented with reasoning.
 
-## Phase 5: Summary
+## Phase 5: Commit
+
+Commit your work to your worktree branch. **Do not push** and **do not open a PR** — the coordinator integrates your branch by rebasing these commits onto the feature branch, so the work must be committed to survive.
+
+```bash
+git add -A
+git commit -m "<type>: <concise description of the change>"
+```
+
+- Use a conventional-commit subject (`feat:`, `fix:`, `test:`, `refactor:`, etc.).
+- lefthook's pre-commit hook runs lint + typecheck; a clean Phase 3 gate means this should pass. **If the pre-commit hook blocks the commit, stop** — do not bypass it with `--no-verify` or other tricks. Report the block in your summary.
+- Stage everything you changed (new test files, production code). Don't leave intended changes uncommitted.
+
+**Gate:** Your changes are committed on the worktree branch. Capture the full commit hash for the summary.
+
+## Phase 6: Summary
 
 **This must be the very last thing you output.** The coordinator reads your result — keep it concise to avoid polluting its context.
 

--- a/.claude/skills/reviewer-correctness/SKILL.md
+++ b/.claude/skills/reviewer-correctness/SKILL.md
@@ -58,7 +58,7 @@ For each file in the diff, check:
 
 #### Security
 - Input validation at system boundaries
-- SQL injection, command injection, XSS
+- Injection risks (SQL, command, XSS, template, SSRF, etc.)
 - Authentication/authorization gaps
 - Secrets in code or logs
 - Unsafe type assertions or casts

--- a/.claude/skills/reviewer-tests/SKILL.md
+++ b/.claude/skills/reviewer-tests/SKILL.md
@@ -65,10 +65,16 @@ Then check:
 - Could a completely wrong implementation still pass? (sign of over-mocking or weak assertions)
 - Flag low-value tests: tautologies (`expect(x).toBeDefined()` with no further assertion), asserting a call succeeded without checking the result, no assertions, exhaustive unit tests for constructors/getters/wiring
 
+#### Mock vs Real Behavior
+- Do tests only exercise mocks, never the real logic under test?
+- Are mocks asserting *what was sent to them* — repository call arguments, the SQL query, the HTTP request body — not just that they were called?
+
 #### Integration Test Coverage
 - Are database interactions tested against a real local Supabase instance (with migrations applied), not just mocked?
 - Do integration tests cover critical paths end-to-end? (HTTP request → route handler → repository → Postgres → response)
 - Are SQL queries, RLS policies, and migrations tested together?
+- For auth/RBAC code: is the permission boundary verified against real fixtures (real roles/namespaces), not just a stubbed auth context?
+- Is there an appropriate balance of unit vs integration tests? (unit tests for pure logic, integration tests for I/O boundaries — persistence, API routes, auth)
 
 #### Edge Cases & Skipped Tests
 - Are error paths, boundary conditions, and concurrent scenarios tested where relevant?

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Dependencies
-node_modules/
+# No trailing slash: also ignores the node_modules symlink that worktrees create.
+node_modules
 __pycache__/
 *.pyc
 .venv/


### PR DESCRIPTION
## Summary
Audited `.claude/skills` and hooks against the canonical `jdelfino/agent-workflow` and `jdelfino/eval` repos. Fixes a real contradiction in the implementer workflow plus a coordinator numbering bug, ports a missing SessionStart safety hook, and backports two review-guidance improvements.

## Changes
- **implementer — commit model (the headline fix):** the skill said "no commits" in both the frontmatter and the intro, yet the entire workflow depends on the implementer committing to its worktree branch — Phase 6 reports a commit hash, lefthook gates the commit, and the coordinator integrates via `git rebase` + `git branch -f` then `git worktree remove --force` (which *discards* uncommitted work). Dropped the "no commits" claims and added an explicit **Phase 5: Commit**. (agent-workflow only half-fixed this: it dropped one mention but kept the frontmatter claim and never added a commit step.)
- **coordinator — numbering bug:** two sections were both labelled `### 3`. Pre-PR Review subsections renumbered `3a`/`3b`; Create PR promoted to `### 4`; cross-references updated.
- **session-start.sh (new) — ported from eval:** warns when a `/clear`'d session inherits a non-main branch in the main checkout (the deterministic stale-*worktree* hooks don't cover this case). Dropped eval's GitHub App token plumbing (removed from this repo) and folded the existing inline `bd prime` into the hook.
- **reviewer-tests:** added a "Mock vs Real Behavior" check and two integration bullets (auth/RBAC permission boundary verified against real fixtures; unit-vs-integration balance).
- **reviewer-correctness:** broadened injection wording (SQL/command/XSS/template/SSRF).
- **.gitignore:** `node_modules` without a trailing slash so the worktree `node_modules` symlink is ignored.

Audit findings deliberately NOT changed: planner and reviewer-architecture are already in sync; merge-queue already has the draft-PR exclusion and GitHub-issue summary line (an audit agent flagged these incorrectly — verified against the actual file); eval-specific bits (GitHub App token sections) are not applicable here.

## Test plan
- [x] `settings.json` valid JSON; `session-start.sh` passes `bash -n` and runs clean (no stale warning in-worktree, `bd prime` fires)
- [x] All phase cross-references reconciled (implementer Phase 6 Summary; coordinator "(Phase 6)")
- [ ] N/A — docs/config only, no app code touched

Beads: coding-ryd

Generated with Claude Code