### PR TITLE
fix(devcontainer): set core.checkStat=minimal to stop false-dirty rebases

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -5,6 +5,13 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
+# The workspace is a FUSE bind mount (DevPod 'fakeowner', consistency=cached).
+# git's default stat check compares inode/uid/gid/ctime/mtime-ns, which this
+# mount reports unreliably, so git treats unchanged files as dirty — `git status`
+# looks clean but `git rebase`/`git pull` abort with "local changes would be
+# overwritten". `minimal` compares only mtime + size and avoids the false dirty.
+git config --local core.checkStat minimal
+
 # Install beads (git hooks are orchestrated by lefthook — see lefthook.yml —
 # which calls `bd hooks run <stage>`, so we do NOT run `bd hooks install`).
 curl -fsSL https://raw.githubusercontent.com/steveyegge/beads/main/scripts/install.sh | bash


### PR DESCRIPTION
## Summary
The devcontainer workspace is a FUSE bind mount (DevPod `fakeowner`, `consistency=cached`) whose `inode`/`uid`/`gid`/`ctime`/`mtime-ns` stat fields are unreliable. With git's default `core.checkStat`, content-identical files get treated as dirty: `git status` reports clean (it does a content-level refresh), but `git rebase` and `git pull` abort with `Your local changes would be overwritten by merge` during their internal checkout.

This bit us during the merge of #76 — the rebase onto main failed repeatedly with a phantom dirty tree until `core.checkStat minimal` was set.

`minimal` makes git compare only `mtime` + `size`, which the mount reports reliably. This matches `jdelfino/eval`'s `.devcontainer/post-create.sh`.

## Changes
- `.devcontainer/post-create.sh`: `git config --local core.checkStat minimal`, with a comment explaining the mount/stat cause.

## Test plan
- [x] `bash -n` clean
- [x] Verified live: setting `core.checkStat minimal` unblocked the previously-failing rebase in this same environment
- [ ] Full effect applies on next container rebuild (post-create runs the config)

Beads: coding-n52

Generated with Claude Code