### PR TITLE
feat(problems): Duplicate action in the Problem Library

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,25 +83,23 @@ jobs:
 
       # Run only the real-DB gated integration tests.
       #
-      # Targeting strategy: two test locations need to run here:
-      #   1. src/server/auth/__tests__/supabase-integration.test.ts — the auth
-      #      integration suite (already matched by the server project testMatch,
-      #      but excluded from the unit `test` job because it requires a live DB).
-      #   2. src/server/persistence/supabase/__tests__/integration/*.integration.test.ts
-      #      — e.g. problem-duplicate.test.ts — excluded from all normal runs by
-      #      the root testPathIgnorePatterns in jest.config.js.
+      # These suites use `describeIfSupabase` (describe.skip when SUPABASE_SECRET_KEY
+      # is absent) so they skip cleanly in the default `test` job. This job sets
+      # SUPABASE_SECRET_KEY, so they actually run here.
       #
-      # We use --testPathPattern to target both paths in one invocation and pass
-      # --testPathIgnorePatterns="" to override the config-level exclusion so the
-      # *.integration.test.ts files are actually picked up.  The server Jest
-      # project (node environment) covers both locations; --selectProjects=server
-      # avoids loading the jsdom/client project which has nothing to run here.
+      # Targeting: match files by the '-integration.test.ts' hyphen suffix — the
+      # same convention used by supabase-integration.test.ts. This suffix is NOT
+      # caught by jest.config's '\\.integration\\.test\\.(ts|tsx)$' dot-pattern
+      # ignore rule, so these files are already in the normal server project
+      # testMatch — we just need SUPABASE_SECRET_KEY set for describeIfSupabase
+      # to activate. --testPathPatterns (Jest 30+) filters to those two files;
+      # --selectProjects=server avoids loading the jsdom/client project which has
+      # nothing to run here.
       - name: Run integration tests
         run: |
           npx jest \
             --selectProjects=server \
-            --testPathPattern="supabase-integration\.test\.ts|/__tests__/integration/" \
-            --testPathIgnorePatterns="/node_modules/" \
+            --testPathPatterns="-integration\.test\.ts$" \
             --runInBand \
             --forceExit
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,3 +38,73 @@ jobs:
         with:
           fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
+
+  integration-tests:
+    name: Integration Tests (real DB)
+    runs-on: ubuntu-latest
+    # No `needs:` — runs in parallel with the `test` and `e2e` jobs.
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Setup Supabase CLI
+        uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      # Start Supabase early so it initialises while npm ci runs.
+      - name: Start Supabase (background)
+        run: |
+          supabase start --exclude studio,storage-api,imgproxy,edge-runtime,logflare,vector,postgres-meta,supavisor &
+          echo "Supabase starting in background..."
+
+      - name: Install dependencies
+        run: npm ci
+
+      # Poll until the REST endpoint is reachable, then capture keys.
+      - name: Wait for Supabase and capture keys
+        run: |
+          echo "Waiting for Supabase to be ready..."
+          for i in {1..60}; do
+            if curl -s http://127.0.0.1:54321/rest/v1/ > /dev/null 2>&1; then
+              echo "Supabase is ready!"
+              break
+            fi
+            echo "Waiting... ($i/60)"
+            sleep 2
+          done
+          supabase status --output env | grep -E '^(ANON_KEY|SERVICE_ROLE_KEY)=' | sed 's/"//g' >> $GITHUB_ENV
+
+      # Run only the real-DB gated integration tests.
+      #
+      # Targeting strategy: two test locations need to run here:
+      #   1. src/server/auth/__tests__/supabase-integration.test.ts — the auth
+      #      integration suite (already matched by the server project testMatch,
+      #      but excluded from the unit `test` job because it requires a live DB).
+      #   2. src/server/persistence/supabase/__tests__/integration/*.integration.test.ts
+      #      — e.g. problem-duplicate.test.ts — excluded from all normal runs by
+      #      the root testPathIgnorePatterns in jest.config.js.
+      #
+      # We use --testPathPattern to target both paths in one invocation and pass
+      # --testPathIgnorePatterns="" to override the config-level exclusion so the
+      # *.integration.test.ts files are actually picked up.  The server Jest
+      # project (node environment) covers both locations; --selectProjects=server
+      # avoids loading the jsdom/client project which has nothing to run here.
+      - name: Run integration tests
+        run: |
+          npx jest \
+            --selectProjects=server \
+            --testPathPattern="supabase-integration\.test\.ts|/__tests__/integration/" \
+            --testPathIgnorePatterns="/node_modules/" \
+            --runInBand \
+            --forceExit
+        env:
+          NEXT_PUBLIC_SUPABASE_URL: http://127.0.0.1:54321
+          NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: ${{ env.ANON_KEY }}
+          SUPABASE_SECRET_KEY: ${{ env.SERVICE_ROLE_KEY }}

--- a/e2e/duplicate-problem.spec.ts
+++ b/e2e/duplicate-problem.spec.ts
@@ -1,0 +1,116 @@
+import { test, expect } from './helpers/setup';
+import { hasSupabaseCredentials } from './helpers/db-helpers';
+import {
+  loginAsInstructor,
+  generateTestNamespaceId,
+  createTestNamespace,
+  cleanupNamespace,
+} from './fixtures/auth-helpers';
+import { getSupabaseAdmin, createTestClass, createTestSection, createTestProblem } from './helpers/test-data';
+
+/**
+ * Duplicate Problem E2E Tests
+ *
+ * Verifies the end-to-end Duplicate feature in the Problem Library:
+ * - The Duplicate button calls the endpoint and produces a copy titled '<title> (copy)'
+ * - The copy appears in the library immediately after duplication
+ * - The copy is editable: the duplicator can open it via Edit, change the title, save, and
+ *   the change persists across a page reload.
+ *
+ * This smoke test catches: button not wired, endpoint failure, copy not appearing in the list,
+ * and copy not editable (e.g. wrong authorId stored). It does NOT verify cross-author RLS
+ * (that is covered by the real-DB integration test in coding-xtz.1).
+ */
+
+const describeE2E = hasSupabaseCredentials() ? test.describe : test.describe.skip;
+
+describeE2E('Duplicate Problem', () => {
+  test('duplicated problem appears as copy, can be edited and title persists', async ({ page }) => {
+    test.setTimeout(60000);
+
+    const namespaceId = generateTestNamespaceId();
+    await createTestNamespace(namespaceId);
+
+    try {
+      // ===== SETUP: create instructor and a seeded problem via Supabase =====
+      const instructor = await loginAsInstructor(page, `instructor-${namespaceId}`, namespaceId);
+
+      const supabase = getSupabaseAdmin();
+      const testClass = await createTestClass(supabase, namespaceId, instructor.id, 'E2E Test Class');
+      await createTestSection(supabase, testClass.id, namespaceId);
+
+      const originalTitle = 'My Seeded Problem';
+      await createTestProblem(supabase, {
+        classId: testClass.id,
+        namespaceId,
+        authorId: instructor.id,
+        title: originalTitle,
+        description: 'A problem created for duplicate E2E testing',
+      });
+
+      // ===== Navigate to the Problem Library =====
+      await page.goto('/instructor/problems');
+      await expect(page.locator('h2:has-text("Problem Library")')).toBeVisible({ timeout: 10000 });
+
+      // Wait for the seeded problem card to appear
+      const originalCard = page.locator(`h3:has-text("${originalTitle}")`).first();
+      await expect(originalCard).toBeVisible({ timeout: 10000 });
+
+      // ===== Click Duplicate on the seeded problem =====
+      // The Duplicate button is in the card's action row alongside Edit / Delete.
+      // Each problem renders as a <div class="bg-white border ..."> card.
+      // Scope to the card containing the original title so we don't click the wrong one
+      // if there are multiple problems in the list.
+      const cardContainer = page.locator(`div.border:has(h3:has-text("${originalTitle}"))`).first();
+      const duplicateButton = cardContainer.locator('button:has-text("Duplicate")').first();
+      await expect(duplicateButton).toBeVisible({ timeout: 5000 });
+      await duplicateButton.click();
+
+      // ===== Assert the copy appears in the library =====
+      const copyTitle = `${originalTitle} (copy)`;
+      const copyCard = page.locator(`h3:has-text("${copyTitle}")`).first();
+      await expect(copyCard).toBeVisible({ timeout: 10000 });
+
+      // ===== Open the copy via Edit =====
+      const copyCardContainer = page.locator(`div.border:has(h3:has-text("${copyTitle}"))`).first();
+      const editButton = copyCardContainer.locator('button:has-text("Edit")').first();
+      await expect(editButton).toBeVisible({ timeout: 5000 });
+      await editButton.click();
+
+      // The problems page shows the ProblemCreator when ?edit=<id> is in the URL
+      await page.waitForURL(/\/instructor\/problems\?edit=/, { timeout: 10000 });
+
+      // The ProblemCreator should load with the copy's title pre-filled.
+      // The title input is rendered inside the CodeEditor panel with id="problem-title".
+      const titleInput = page.locator('input#problem-title');
+      await expect(titleInput).toBeVisible({ timeout: 10000 });
+      await expect(titleInput).toHaveValue(copyTitle, { timeout: 5000 });
+
+      // ===== Change the title and save =====
+      const editedTitle = 'My Edited Copy';
+      await titleInput.clear();
+      await titleInput.fill(editedTitle);
+
+      // Click the "Update Problem" submit button
+      const saveButton = page.locator('button:has-text("Update Problem")').first();
+      await expect(saveButton).toBeVisible({ timeout: 5000 });
+      await saveButton.click();
+
+      // After save the page navigates back to the library
+      await page.waitForURL('/instructor/problems', { timeout: 10000 });
+      await expect(page.locator('h2:has-text("Problem Library")')).toBeVisible({ timeout: 5000 });
+
+      // ===== Reload and verify the edited title persisted =====
+      await page.reload();
+      await expect(page.locator('h2:has-text("Problem Library")')).toBeVisible({ timeout: 10000 });
+
+      // The edited title must appear (proves it was saved to the DB, not just local state)
+      await expect(page.locator(`h3:has-text("${editedTitle}")`).first()).toBeVisible({ timeout: 10000 });
+
+      // The original problem must still be there (duplicate does not touch the original)
+      await expect(page.locator(`h3:has-text("${originalTitle}")`).first()).toBeVisible({ timeout: 5000 });
+    } finally {
+      await cleanupNamespace(namespaceId);
+    }
+  });
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -33,7 +33,7 @@ export default defineConfig({
   /* Shared settings for all the projects below */
   use: {
     /* Base URL to use in actions like `await page.goto('/')` */
-    baseURL: 'http://localhost:3000',
+    baseURL: process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:3000',
 
     /* Collect trace when retrying the failed test */
     trace: 'on-first-retry',
@@ -57,7 +57,7 @@ export default defineConfig({
   webServer: {
     // Use production build in CI for stability, dev mode locally for speed
     command: process.env.CI ? 'npm run build && npm start' : 'npm run dev',
-    url: 'http://localhost:3000',
+    url: process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:3000',
     reuseExistingServer: !process.env.CI,
     timeout: 120 * 1000, // 2 minutes to start
     // Pass environment variables to the dev server subprocess

--- a/src/app/(app)/instructor/components/ProblemCard.tsx
+++ b/src/app/(app)/instructor/components/ProblemCard.tsx
@@ -18,6 +18,7 @@ interface ProblemCardProps {
   onEdit: (problemId: string) => void;
   onDelete: (problemId: string, title: string) => void;
   onCreateSession: (problemId: string) => void;
+  onDuplicate: (problemId: string) => void;
   onTagClick?: (tag: string) => void;
 }
 
@@ -27,6 +28,7 @@ export default function ProblemCard({
   onEdit,
   onDelete,
   onCreateSession,
+  onDuplicate,
   onTagClick,
 }: ProblemCardProps) {
   const [isDeleting, setIsDeleting] = useState(false);
@@ -107,6 +109,13 @@ export default function ProblemCard({
             >
               Edit
             </button>
+            <button
+              onClick={() => onDuplicate(problem.id)}
+              className="px-3 py-1.5 text-sm text-gray-600 hover:bg-gray-50 rounded-lg transition-colors"
+              title="Duplicate problem"
+            >
+              Duplicate
+            </button>
             <CopyLinkDropdown problemId={problem.id} classId={problem.classId} />
             <button
               onClick={() => onCreateSession(problem.id)}
@@ -163,6 +172,13 @@ export default function ProblemCard({
           className="col-span-2 px-3 py-2 text-sm text-blue-600 border border-blue-600 hover:bg-blue-50 rounded-lg transition-colors"
         >
           Edit
+        </button>
+        <button
+          onClick={() => onDuplicate(problem.id)}
+          className="col-span-2 px-3 py-2 text-sm text-gray-600 border border-gray-300 hover:bg-gray-50 rounded-lg transition-colors"
+          title="Duplicate problem"
+        >
+          Duplicate
         </button>
         <div className="col-span-2">
           <CopyLinkDropdown problemId={problem.id} classId={problem.classId} />

--- a/src/app/(app)/instructor/components/ProblemLibrary.tsx
+++ b/src/app/(app)/instructor/components/ProblemLibrary.tsx
@@ -201,6 +201,25 @@ export default function ProblemLibrary({ onCreateNew, onEdit }: ProblemLibraryPr
     }
   };
 
+  const handleDuplicate = async (problemId: string) => {
+    try {
+      const response = await fetch(`/api/problems/${problemId}/duplicate`, {
+        method: 'POST',
+      });
+
+      if (!response.ok) {
+        const data = await response.json();
+        throw new Error(data.error || 'Failed to duplicate problem');
+      }
+
+      // Reload problems so the new copy appears
+      await loadProblems();
+    } catch (err) {
+      console.error('Error duplicating problem:', err);
+      alert(`Failed to duplicate problem: ${err instanceof Error ? err.message : 'Unknown error'}`);
+    }
+  };
+
   const handleCreateSession = (problemId: string) => {
     const problem = problems.find(p => p.id === problemId);
     if (!problem) {
@@ -350,6 +369,7 @@ export default function ProblemLibrary({ onCreateNew, onEdit }: ProblemLibraryPr
               onEdit={handleEdit}
               onDelete={handleDelete}
               onCreateSession={handleCreateSession}
+              onDuplicate={handleDuplicate}
               onTagClick={handleTagToggle}
             />
           ))}

--- a/src/app/(app)/instructor/components/__tests__/ProblemCard.test.tsx
+++ b/src/app/(app)/instructor/components/__tests__/ProblemCard.test.tsx
@@ -24,6 +24,7 @@ describe('ProblemCard', () => {
     onEdit: jest.fn(),
     onDelete: jest.fn(),
     onCreateSession: jest.fn(),
+    onDuplicate: jest.fn(),
   };
 
   beforeEach(() => {
@@ -66,6 +67,17 @@ describe('ProblemCard', () => {
       render(<ProblemCard {...defaultProps} />);
       fireEvent.click(screen.getByText('Create Session'));
       expect(defaultProps.onCreateSession).toHaveBeenCalledWith('problem-123');
+    });
+
+    it('calls onDuplicate with the problem id when Duplicate button is clicked', () => {
+      /**
+       * Verifies that clicking Duplicate calls onDuplicate with the correct problem id.
+       * The button must be present and wired to the prop — omitting onDuplicate or
+       * passing the wrong id would break the feature end-to-end.
+       */
+      render(<ProblemCard {...defaultProps} />);
+      fireEvent.click(screen.getByTitle('Duplicate problem'));
+      expect(defaultProps.onDuplicate).toHaveBeenCalledWith('problem-123');
     });
 
     it('shows confirmation dialog when Delete button is clicked', async () => {
@@ -155,6 +167,13 @@ describe('ProblemCard', () => {
       expect(screen.getByText('Edit')).toBeInTheDocument();
       expect(screen.getByText('Create Session')).toBeInTheDocument();
       expect(screen.getByText('Delete')).toBeInTheDocument();
+      expect(screen.getByText('Duplicate')).toBeInTheDocument();
+    });
+
+    it('calls onDuplicate with the problem id when Duplicate button is clicked in grid view', () => {
+      render(<ProblemCard {...gridProps} />);
+      fireEvent.click(screen.getByText('Duplicate'));
+      expect(defaultProps.onDuplicate).toHaveBeenCalledWith('problem-123');
     });
 
     it('handles actions in grid view', () => {

--- a/src/app/(app)/instructor/components/__tests__/ProblemLibrary.test.tsx
+++ b/src/app/(app)/instructor/components/__tests__/ProblemLibrary.test.tsx
@@ -40,6 +40,7 @@ jest.mock('../ProblemCard', () => {
         {props.problem.title}
         <button data-testid={`edit-${props.problem.id}`} onClick={() => props.onEdit(props.problem.id)}>Edit</button>
         <button data-testid={`create-session-${props.problem.id}`} onClick={() => props.onCreateSession(props.problem.id)}>Create Session</button>
+        <button data-testid={`duplicate-${props.problem.id}`} onClick={() => props.onDuplicate(props.problem.id)}>Duplicate</button>
       </div>
     );
   };
@@ -315,6 +316,81 @@ describe('ProblemLibrary', () => {
 
       fireEvent.click(screen.getByTestId('edit-problem-1'));
       expect(mockRouterPush).toHaveBeenCalledWith('/instructor/problems');
+    });
+  });
+
+  describe('Duplicate handler', () => {
+    it('POSTs to /api/problems/{id}/duplicate and reloads the list', async () => {
+      /**
+       * Verifies that handleDuplicate sends a POST to the correct endpoint and
+       * then re-fetches the problem list so the new copy appears.
+       * If the endpoint or reload is missing, the UI will appear to do nothing.
+       */
+      let problemFetchCount = 0;
+      global.fetch = jest.fn((url: string, options?: any) => {
+        if (typeof url === 'string' && url.includes('/api/classes')) {
+          return Promise.resolve({ ok: true, json: () => Promise.resolve({ classes: [] }) });
+        }
+        if (typeof url === 'string' && url.includes('/duplicate') && options?.method === 'POST') {
+          return Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve({ problem: { ...mockProblems[0], id: 'problem-copy', title: 'Problem 1 (copy)' } }),
+          });
+        }
+        problemFetchCount++;
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ problems: mockProblems }) });
+      }) as jest.Mock;
+
+      render(<ProblemLibrary />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('problem-card-problem-1')).toBeInTheDocument();
+      });
+
+      const fetchCountBeforeDuplicate = problemFetchCount;
+      fireEvent.click(screen.getByTestId('duplicate-problem-1'));
+
+      await waitFor(() => {
+        expect(global.fetch).toHaveBeenCalledWith(
+          '/api/problems/problem-1/duplicate',
+          expect.objectContaining({ method: 'POST' })
+        );
+      });
+
+      await waitFor(() => {
+        expect(problemFetchCount).toBeGreaterThan(fetchCountBeforeDuplicate);
+      });
+    });
+
+    it('shows an alert when duplicate fails', async () => {
+      const alertSpy = jest.spyOn(window, 'alert').mockImplementation(() => {});
+
+      global.fetch = jest.fn((url: string, options?: any) => {
+        if (typeof url === 'string' && url.includes('/api/classes')) {
+          return Promise.resolve({ ok: true, json: () => Promise.resolve({ classes: [] }) });
+        }
+        if (typeof url === 'string' && url.includes('/duplicate') && options?.method === 'POST') {
+          return Promise.resolve({
+            ok: false,
+            json: () => Promise.resolve({ error: 'Duplicate failed' }),
+          });
+        }
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ problems: mockProblems }) });
+      }) as jest.Mock;
+
+      render(<ProblemLibrary />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('problem-card-problem-1')).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByTestId('duplicate-problem-1'));
+
+      await waitFor(() => {
+        expect(alertSpy).toHaveBeenCalledWith(expect.stringContaining('Duplicate failed'));
+      });
+
+      alertSpy.mockRestore();
     });
   });
 

--- a/src/app/api/problems/[id]/duplicate/__tests__/route.test.ts
+++ b/src/app/api/problems/[id]/duplicate/__tests__/route.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Tests for POST /api/problems/[id]/duplicate
+ *
+ * Verifies:
+ * - Instructor can duplicate a problem: returns 201 with title ending ' (copy)',
+ *   authorId === caller, namespaceId === caller's namespace.
+ * - Student gets 403; nothing is created.
+ * - Cross-namespace problem id (getById returns null scoped to caller's namespace) -> 404.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { POST } from '../route';
+import { createStorage } from '@/server/persistence';
+
+// Mock dependencies
+jest.mock('@/server/persistence');
+
+jest.mock('@/server/auth/api-helpers', () => ({
+  requireAuth: jest.fn(),
+  getNamespaceContext: jest.fn((req: any, user: any) => user.namespaceId || 'default'),
+}));
+
+import { requireAuth, getNamespaceContext } from '@/server/auth/api-helpers';
+import type { User } from '@/server/auth/types';
+import { RBACService } from '@/server/auth/rbac';
+
+const mockCreateStorage = createStorage as jest.MockedFunction<typeof createStorage>;
+
+// Per-file pattern from route.test.ts
+function createAuthContext(user: User) {
+  return {
+    user,
+    accessToken: 'test-access-token',
+    rbac: new RBACService(user),
+  };
+}
+
+const mockInstructorUser: User = {
+  id: 'caller-instructor-id',
+  email: 'instructor@example.com',
+  role: 'instructor',
+  namespaceId: 'ns-caller',
+  createdAt: new Date('2025-01-01'),
+};
+
+const mockStudentUser: User = {
+  id: 'caller-student-id',
+  email: 'student@example.com',
+  role: 'student',
+  namespaceId: 'ns-caller',
+  createdAt: new Date('2025-01-01'),
+};
+
+const mockOriginalProblem = {
+  id: 'problem-original',
+  namespaceId: 'ns-caller',
+  title: 'Original Problem',
+  description: 'A description',
+  starterCode: 'def solve(): pass',
+  solution: 'def solve(): return 42',
+  testCases: [],
+  executionSettings: undefined,
+  authorId: 'other-instructor-id',
+  classId: 'class-1',
+  tags: ['loops'],
+  createdAt: new Date('2025-01-01'),
+  updatedAt: new Date('2025-01-01'),
+};
+
+function makeRequest(id: string): NextRequest {
+  return new NextRequest(`http://localhost/api/problems/${id}/duplicate`, {
+    method: 'POST',
+  });
+}
+
+function makeParams(id: string) {
+  return { params: Promise.resolve({ id }) };
+}
+
+describe('POST /api/problems/[id]/duplicate', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('instructor role', () => {
+    it('returns 201 with title ending (copy), authorId === caller, namespaceId === caller ns', async () => {
+      /**
+       * Contract: instructor can duplicate any problem in their namespace;
+       * the copy is owned by the caller (not the original author) and has
+       * title = original.title + ' (copy)'.
+       * Verifies the core ownership-transfer behavior at the route level.
+       */
+      (requireAuth as jest.Mock).mockResolvedValue(createAuthContext(mockInstructorUser));
+
+      const duplicatedProblem = {
+        ...mockOriginalProblem,
+        id: 'problem-copy',
+        title: 'Original Problem (copy)',
+        authorId: mockInstructorUser.id,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      const getByIdMock = jest.fn().mockResolvedValue(mockOriginalProblem);
+      const duplicateMock = jest.fn().mockResolvedValue(duplicatedProblem);
+
+      mockCreateStorage.mockResolvedValue({
+        problems: {
+          getById: getByIdMock,
+          duplicate: duplicateMock,
+        },
+      } as any);
+
+      const response = await POST(makeRequest('problem-original'), makeParams('problem-original'));
+      const data = await response.json();
+
+      expect(response.status).toBe(201);
+      expect(data.problem.title).toBe('Original Problem (copy)');
+      expect(data.problem.authorId).toBe(mockInstructorUser.id);
+      expect(data.problem.namespaceId).toBe(mockInstructorUser.namespaceId);
+
+      // Verify it called getById scoped to caller namespace
+      expect(getByIdMock).toHaveBeenCalledWith('problem-original', 'ns-caller');
+
+      // Verify duplicate called with correct args
+      expect(duplicateMock).toHaveBeenCalledWith(
+        'problem-original',
+        'Original Problem (copy)',
+        mockInstructorUser.id
+      );
+    });
+  });
+
+  describe('student role', () => {
+    it('returns 403 and does not create a copy', async () => {
+      /**
+       * Contract: students cannot duplicate problems (role below instructor).
+       * Ensures the INLINE role check mirrors POST /api/problems behavior.
+       */
+      (requireAuth as jest.Mock).mockResolvedValue(createAuthContext(mockStudentUser));
+
+      const duplicateMock = jest.fn();
+      mockCreateStorage.mockResolvedValue({
+        problems: {
+          getById: jest.fn(),
+          duplicate: duplicateMock,
+        },
+      } as any);
+
+      const response = await POST(makeRequest('problem-original'), makeParams('problem-original'));
+      const data = await response.json();
+
+      expect(response.status).toBe(403);
+      expect(duplicateMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('cross-namespace problem id', () => {
+    it('returns 404 and does not create a copy when problem not found in caller namespace', async () => {
+      /**
+       * Contract: if getById returns null (problem missing or in another namespace),
+       * the route returns 404 and does NOT call duplicate().
+       * Prevents cross-namespace data copying.
+       */
+      (requireAuth as jest.Mock).mockResolvedValue(createAuthContext(mockInstructorUser));
+
+      const duplicateMock = jest.fn();
+      mockCreateStorage.mockResolvedValue({
+        problems: {
+          getById: jest.fn().mockResolvedValue(null),
+          duplicate: duplicateMock,
+        },
+      } as any);
+
+      const response = await POST(
+        makeRequest('problem-from-other-ns'),
+        makeParams('problem-from-other-ns')
+      );
+      const data = await response.json();
+
+      expect(response.status).toBe(404);
+      expect(duplicateMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('unauthenticated request', () => {
+    it('returns 401 when not authenticated', async () => {
+      (requireAuth as jest.Mock).mockResolvedValue(
+        NextResponse.json({ error: 'Not authenticated' }, { status: 401 })
+      );
+
+      const response = await POST(makeRequest('problem-original'), makeParams('problem-original'));
+
+      expect(response.status).toBe(401);
+    });
+  });
+});

--- a/src/app/api/problems/[id]/duplicate/route.ts
+++ b/src/app/api/problems/[id]/duplicate/route.ts
@@ -1,0 +1,80 @@
+/**
+ * Duplicate problem endpoint
+ *
+ * POST /api/problems/[id]/duplicate
+ *
+ * Creates a copy of an existing problem, owned by the caller.
+ * Only instructors and admins can duplicate problems.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { createStorage } from '@/server/persistence';
+import { requireAuth, getNamespaceContext } from '@/server/auth/api-helpers';
+import { rateLimit } from '@/server/rate-limit';
+
+type Params = {
+  params: Promise<{
+    id: string;
+  }>;
+};
+
+/**
+ * POST /api/problems/[id]/duplicate
+ *
+ * Duplicate a problem.
+ * - requireAuth; roles below instructor get 403 (inline check, same as POST /api/problems).
+ * - Loads the original scoped to caller's namespace; 404 if not found.
+ * - Creates a copy with title = original.title + ' (copy)' and authorId = caller.
+ * - Returns { problem } with 201.
+ */
+export async function POST(
+  request: NextRequest,
+  { params }: Params
+) {
+  try {
+    const { id } = await params;
+    const auth = await requireAuth(request);
+    if (auth instanceof NextResponse) {
+      return auth; // Return 401 error response
+    }
+
+    const { user, accessToken } = auth;
+
+    // Rate limit by user ID (write operation)
+    const limited = await rateLimit('write', request, user.id);
+    if (limited) return limited;
+
+    // Only instructors and admins can duplicate problems
+    if (user.role !== 'instructor' && user.role !== 'namespace-admin' && user.role !== 'system-admin') {
+      return NextResponse.json(
+        { error: 'Forbidden: Only instructors can duplicate problems' },
+        { status: 403 }
+      );
+    }
+
+    const namespaceId = getNamespaceContext(request, user);
+    const storage = await createStorage(accessToken);
+
+    // Load the original, scoped to caller's namespace (returns null for other namespaces)
+    const original = await storage.problems.getById(id, namespaceId);
+    if (!original) {
+      return NextResponse.json(
+        { error: 'Problem not found' },
+        { status: 404 }
+      );
+    }
+
+    const newTitle = `${original.title} (copy)`;
+
+    // Duplicate with caller as the new author so they can edit it under RLS
+    const problem = await storage.problems.duplicate(id, newTitle, user.id);
+
+    return NextResponse.json({ problem }, { status: 201 });
+  } catch (error: any) {
+    console.error('Error duplicating problem:', error);
+    return NextResponse.json(
+      { error: error.message || 'Failed to duplicate problem' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/server/persistence/interfaces.ts
+++ b/src/server/persistence/interfaces.ts
@@ -296,16 +296,20 @@ export interface IProblemRepository {
   getByClass(classId: string, filter?: ProblemFilter, namespaceId?: string): Promise<ProblemMetadata[]>;
 
   /**
-   * Duplicate a problem with new title
+   * Duplicate a problem with new title and new author
    *
-   * Creates a copy with new ID and specified title.
+   * Creates a copy with new ID, specified title, and specified author.
+   * All content fields (description, starterCode, solution, testCases,
+   * executionSettings, tags, classId) carry over from the original.
+   * namespaceId also carries over. id and timestamps are reset.
    *
    * @param id - Problem to duplicate
    * @param newTitle - Title for the duplicate
+   * @param newAuthorId - User ID of the new author (the duplicator, NOT the original author)
    * @returns The duplicated problem
    * @throws {PersistenceError} with NOT_FOUND if problem doesn't exist
    */
-  duplicate(id: string, newTitle: string): Promise<Problem>;
+  duplicate(id: string, newTitle: string, newAuthorId: string): Promise<Problem>;
 }
 
 /**

--- a/src/server/persistence/supabase/__tests__/integration/problem-duplicate.test.ts
+++ b/src/server/persistence/supabase/__tests__/integration/problem-duplicate.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Real-DB integration test: duplicate() ownership transfer + RLS editability
+ *
+ * Contract verified: when instructor A duplicates a problem authored by instructor B,
+ * the copy's authorId must be A (NOT B), and A must be able to UPDATE the copy
+ * under real RLS (the repo is scoped to A's access token). This is the core
+ * correctness guarantee of the Duplicate feature — without it a duplicator
+ * cannot edit their own copy.
+ *
+ * Why it matters: duplicate() previously copied the original author's id.
+ * Under Supabase RLS, only the author (or admin) can edit a problem. If the
+ * copy retains B's authorId, A cannot edit it despite being the creator.
+ *
+ * What breaks if violated: instructors would receive "Forbidden" when editing
+ * duplicated problems they do not own.
+ *
+ * Prerequisites: local Supabase running with SUPABASE_SECRET_KEY set.
+ * This test SKIPS automatically when credentials are not present.
+ * CAVEAT: This test will not run in default CI (no SUPABASE_SECRET_KEY set).
+ * coding-xtz.4 adds the CI job that makes it run and required.
+ */
+
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
+import { SupabaseProblemRepository } from '../../problem-repository';
+import { SupabaseAuthProvider } from '../../../../auth/supabase-provider';
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const serviceRoleKey = process.env.SUPABASE_SECRET_KEY;
+const hasSupabaseCredentials = Boolean(supabaseUrl && serviceRoleKey);
+
+const describeIfSupabase = hasSupabaseCredentials ? describe : describe.skip;
+
+describeIfSupabase('Problem duplicate() — ownership transfer + RLS editability', () => {
+  let adminClient: SupabaseClient;
+  let authProvider: SupabaseAuthProvider;
+
+  // Track created user IDs for cleanup
+  const createdUserIds: string[] = [];
+  // Track created problem IDs for cleanup
+  const createdProblemIds: string[] = [];
+
+  const TEST_EMAIL_SUFFIX = '@problem-duplicate-integration.local';
+
+  beforeAll(() => {
+    adminClient = createClient(supabaseUrl!, serviceRoleKey!, {
+      auth: {
+        autoRefreshToken: false,
+        persistSession: false,
+      },
+    });
+    authProvider = new SupabaseAuthProvider();
+  });
+
+  afterEach(async () => {
+    // Clean up created problems first (FK safety)
+    for (const id of createdProblemIds) {
+      await adminClient.from('problems').delete().eq('id', id);
+    }
+    createdProblemIds.length = 0;
+
+    // Clean up created users
+    for (const userId of createdUserIds) {
+      try {
+        await adminClient.auth.admin.deleteUser(userId);
+      } catch {
+        // Best-effort cleanup
+      }
+    }
+    createdUserIds.length = 0;
+  });
+
+  it('copy.authorId === A (the duplicator), all content fields match original, A can UPDATE copy under RLS', async () => {
+    // --- Setup ---
+    // Create namespace (use 'default' which is seeded)
+    const namespaceId = 'default';
+    const password = 'testpassword123!';
+
+    // Create instructor A (the duplicator)
+    const userA = await authProvider.signUp(
+      `instructor-a${TEST_EMAIL_SUFFIX}`,
+      password,
+      'instructor',
+      namespaceId
+    );
+    createdUserIds.push(userA.id);
+
+    // Create instructor B (the original problem author)
+    const userB = await authProvider.signUp(
+      `instructor-b${TEST_EMAIL_SUFFIX}`,
+      password,
+      'instructor',
+      namespaceId
+    );
+    createdUserIds.push(userB.id);
+
+    // Find a class in the default namespace to satisfy NOT NULL constraint
+    const { data: classes } = await adminClient
+      .from('classes')
+      .select('id')
+      .eq('namespace_id', namespaceId)
+      .limit(1)
+      .single();
+
+    if (!classes) {
+      throw new Error('No class found in default namespace — run seed-data first');
+    }
+    const classId = classes.id;
+
+    // Create original problem owned by B using the service-role client (bypasses RLS)
+    const serviceRepoB = new SupabaseProblemRepository(serviceRoleKey!);
+    const original = await serviceRepoB.create({
+      namespaceId,
+      title: 'Original Problem by B',
+      description: 'A test description',
+      starterCode: 'def solve(): pass',
+      solution: 'def solve(): return 42',
+      testCases: [],
+      executionSettings: undefined,
+      authorId: userB.id,
+      classId,
+      tags: ['integration', 'test'],
+    });
+    createdProblemIds.push(original.id);
+
+    // --- Act: sign in as A and duplicate via service-role repo (simulates the route call) ---
+    // The route calls storage.problems.duplicate(id, newTitle, user.id) with user A's token.
+    // We use the service-role repo to call duplicate() directly here to avoid
+    // needing to spin up the full Next.js server — the ownership-transfer behavior
+    // is in the repository layer.
+    const serviceRepo = new SupabaseProblemRepository(serviceRoleKey!);
+    const copy = await serviceRepo.duplicate(original.id, `${original.title} (copy)`, userA.id);
+    createdProblemIds.push(copy.id);
+
+    // --- Assert: ownership transferred ---
+    expect(copy.authorId).toBe(userA.id);
+    expect(copy.authorId).not.toBe(userB.id);
+    expect(copy.title).toBe('Original Problem by B (copy)');
+
+    // All content fields carried over
+    expect(copy.description).toBe(original.description);
+    expect(copy.starterCode).toBe(original.starterCode);
+    expect(copy.solution).toBe(original.solution);
+    expect(copy.testCases).toEqual(original.testCases);
+    expect(copy.tags).toEqual(original.tags);
+    expect(copy.classId).toBe(original.classId);
+    expect(copy.namespaceId).toBe(original.namespaceId);
+
+    // id and timestamps are fresh
+    expect(copy.id).not.toBe(original.id);
+    expect(copy.createdAt.getTime()).toBeGreaterThanOrEqual(original.createdAt.getTime());
+
+    // --- Assert: A can update the copy under real RLS ---
+    // Sign in as A to get a real access token (enforces RLS)
+    const { data: signInData } = await adminClient.auth.signInWithPassword({
+      email: `instructor-a${TEST_EMAIL_SUFFIX}`,
+      password,
+    });
+
+    if (!signInData.session) {
+      throw new Error('Failed to sign in as instructor A');
+    }
+
+    const rlsRepoA = new SupabaseProblemRepository(signInData.session.access_token);
+    // This MUST succeed — A is the author of the copy
+    const updated = await rlsRepoA.update(copy.id, { title: 'Updated by A' });
+    expect(updated.title).toBe('Updated by A');
+  });
+});

--- a/src/server/persistence/supabase/__tests__/problem-duplicate-integration.test.ts
+++ b/src/server/persistence/supabase/__tests__/problem-duplicate-integration.test.ts
@@ -16,13 +16,13 @@
  *
  * Prerequisites: local Supabase running with SUPABASE_SECRET_KEY set.
  * This test SKIPS automatically when credentials are not present.
- * CAVEAT: This test will not run in default CI (no SUPABASE_SECRET_KEY set).
- * coding-xtz.4 adds the CI job that makes it run and required.
+ * The default CI `test` job has no SUPABASE_SECRET_KEY, so this suite skips
+ * there; the `integration-tests` CI job sets the key so it actually runs.
  */
 
 import { createClient, SupabaseClient } from '@supabase/supabase-js';
-import { SupabaseProblemRepository } from '../../problem-repository';
-import { SupabaseAuthProvider } from '../../../../auth/supabase-provider';
+import { SupabaseProblemRepository } from '../problem-repository';
+import { SupabaseAuthProvider } from '../../../auth/supabase-provider';
 
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
 const serviceRoleKey = process.env.SUPABASE_SECRET_KEY;
@@ -122,13 +122,24 @@ describeIfSupabase('Problem duplicate() — ownership transfer + RLS editability
     });
     createdProblemIds.push(original.id);
 
-    // --- Act: sign in as A and duplicate via service-role repo (simulates the route call) ---
-    // The route calls storage.problems.duplicate(id, newTitle, user.id) with user A's token.
-    // We use the service-role repo to call duplicate() directly here to avoid
-    // needing to spin up the full Next.js server — the ownership-transfer behavior
-    // is in the repository layer.
-    const serviceRepo = new SupabaseProblemRepository(serviceRoleKey!);
-    const copy = await serviceRepo.duplicate(original.id, `${original.title} (copy)`, userA.id);
+    // --- Act: sign in as A, then duplicate through A's RLS-scoped token ---
+    // The real route calls storage.problems.duplicate(id, newTitle, user.id) with the
+    // caller's access token (createStorage(accessToken)). We replicate that here: sign
+    // in as A, build a SupabaseProblemRepository from A's token, then call duplicate()
+    // through it. This exercises the real getById SELECT + INSERT under RLS (the
+    // problems_insert policy requires is_instructor_or_higher() AND namespace_id =
+    // get_user_namespace_id() — A is an instructor in 'default', so it must pass).
+    const { data: signInData } = await adminClient.auth.signInWithPassword({
+      email: `instructor-a${TEST_EMAIL_SUFFIX}`,
+      password,
+    });
+
+    if (!signInData.session) {
+      throw new Error('Failed to sign in as instructor A');
+    }
+
+    const rlsRepoA = new SupabaseProblemRepository(signInData.session.access_token);
+    const copy = await rlsRepoA.duplicate(original.id, `${original.title} (copy)`, userA.id);
     createdProblemIds.push(copy.id);
 
     // --- Assert: ownership transferred ---
@@ -150,18 +161,7 @@ describeIfSupabase('Problem duplicate() — ownership transfer + RLS editability
     expect(copy.createdAt.getTime()).toBeGreaterThanOrEqual(original.createdAt.getTime());
 
     // --- Assert: A can update the copy under real RLS ---
-    // Sign in as A to get a real access token (enforces RLS)
-    const { data: signInData } = await adminClient.auth.signInWithPassword({
-      email: `instructor-a${TEST_EMAIL_SUFFIX}`,
-      password,
-    });
-
-    if (!signInData.session) {
-      throw new Error('Failed to sign in as instructor A');
-    }
-
-    const rlsRepoA = new SupabaseProblemRepository(signInData.session.access_token);
-    // This MUST succeed — A is the author of the copy
+    // Reuse the same A-token repo — A is the author of the copy so update() MUST succeed.
     const updated = await rlsRepoA.update(copy.id, { title: 'Updated by A' });
     expect(updated.title).toBe('Updated by A');
   });

--- a/src/server/persistence/supabase/__tests__/problem-duplicate-integration.test.ts
+++ b/src/server/persistence/supabase/__tests__/problem-duplicate-integration.test.ts
@@ -20,9 +20,16 @@
  * there; the `integration-tests` CI job sets the key so it actually runs.
  */
 
+// Unmock the Supabase client so this integration test uses the real Supabase instance.
+// setupTests.ts globally mocks @/server/supabase/client for unit tests; we restore
+// the real module here so that SupabaseProblemRepository and SupabaseAuthProvider
+// talk to a live local database rather than the in-memory mock.
+jest.unmock('@/server/supabase/client');
+
 import { createClient, SupabaseClient } from '@supabase/supabase-js';
 import { SupabaseProblemRepository } from '../problem-repository';
 import { SupabaseAuthProvider } from '../../../auth/supabase-provider';
+import { SERVICE_ROLE_MARKER } from '../../../supabase/client';
 
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
 const serviceRoleKey = process.env.SUPABASE_SECRET_KEY;
@@ -30,16 +37,17 @@ const hasSupabaseCredentials = Boolean(supabaseUrl && serviceRoleKey);
 
 const describeIfSupabase = hasSupabaseCredentials ? describe : describe.skip;
 
+// Dedicated namespace for this test — avoids any dependency on seed data.
+// Using a fixed slug makes cleanup deterministic and idempotent across runs.
+const TEST_NAMESPACE_ID = 'duplicate-int-test';
+const TEST_EMAIL_SUFFIX = '@problem-duplicate-integration.local';
+
 describeIfSupabase('Problem duplicate() — ownership transfer + RLS editability', () => {
   let adminClient: SupabaseClient;
   let authProvider: SupabaseAuthProvider;
 
   // Track created user IDs for cleanup
   const createdUserIds: string[] = [];
-  // Track created problem IDs for cleanup
-  const createdProblemIds: string[] = [];
-
-  const TEST_EMAIL_SUFFIX = '@problem-duplicate-integration.local';
 
   beforeAll(() => {
     adminClient = createClient(supabaseUrl!, serviceRoleKey!, {
@@ -52,13 +60,12 @@ describeIfSupabase('Problem duplicate() — ownership transfer + RLS editability
   });
 
   afterEach(async () => {
-    // Clean up created problems first (FK safety)
-    for (const id of createdProblemIds) {
-      await adminClient.from('problems').delete().eq('id', id);
-    }
-    createdProblemIds.length = 0;
+    // Delete the test namespace first — ON DELETE CASCADE removes the class and
+    // all problems in it, so we do not need to track problem IDs separately.
+    await adminClient.from('namespaces').delete().eq('id', TEST_NAMESPACE_ID);
 
-    // Clean up created users
+    // Delete users after namespace (user_profiles are removed via ON DELETE CASCADE
+    // from auth.users, but auth.users itself must be removed via the Admin API).
     for (const userId of createdUserIds) {
       try {
         await adminClient.auth.admin.deleteUser(userId);
@@ -70,46 +77,61 @@ describeIfSupabase('Problem duplicate() — ownership transfer + RLS editability
   });
 
   it('copy.authorId === A (the duplicator), all content fields match original, A can UPDATE copy under RLS', async () => {
-    // --- Setup ---
-    // Create namespace (use 'default' which is seeded)
-    const namespaceId = 'default';
     const password = 'testpassword123!';
 
-    // Create instructor A (the duplicator)
+    // --- Setup: namespace ---
+    // Idempotent: delete any pre-existing stale namespace (from a prior failed run),
+    // then insert fresh. created_by is nullable so we omit it.
+    await adminClient.from('namespaces').delete().eq('id', TEST_NAMESPACE_ID);
+    const { error: nsError } = await adminClient.from('namespaces').insert({
+      id: TEST_NAMESPACE_ID,
+      display_name: 'Duplicate Integration Test Namespace',
+    });
+    if (nsError) {
+      throw new Error(`Failed to create test namespace: ${nsError.message}`);
+    }
+
+    // --- Setup: users ---
+    // Create instructor A (the duplicator) into our dedicated namespace.
     const userA = await authProvider.signUp(
       `instructor-a${TEST_EMAIL_SUFFIX}`,
       password,
       'instructor',
-      namespaceId
+      TEST_NAMESPACE_ID
     );
     createdUserIds.push(userA.id);
 
-    // Create instructor B (the original problem author)
+    // Create instructor B (the original problem author) into the same namespace.
     const userB = await authProvider.signUp(
       `instructor-b${TEST_EMAIL_SUFFIX}`,
       password,
       'instructor',
-      namespaceId
+      TEST_NAMESPACE_ID
     );
     createdUserIds.push(userB.id);
 
-    // Find a class in the default namespace to satisfy NOT NULL constraint
-    const { data: classes } = await adminClient
+    // --- Setup: class ---
+    // Create a class owned by B (classes.created_by is NOT NULL).
+    const { data: classRow, error: classError } = await adminClient
       .from('classes')
+      .insert({
+        namespace_id: TEST_NAMESPACE_ID,
+        name: 'Test Class',
+        created_by: userB.id,
+      })
       .select('id')
-      .eq('namespace_id', namespaceId)
-      .limit(1)
       .single();
 
-    if (!classes) {
-      throw new Error('No class found in default namespace — run seed-data first');
+    if (classError || !classRow) {
+      throw new Error(`Failed to create test class: ${classError?.message}`);
     }
-    const classId = classes.id;
+    const classId = classRow.id;
 
-    // Create original problem owned by B using the service-role client (bypasses RLS)
-    const serviceRepoB = new SupabaseProblemRepository(serviceRoleKey!);
+    // --- Setup: original problem owned by B ---
+    // Use SERVICE_ROLE_MARKER so the repo bypasses RLS (setup must not be gated by B's token).
+    const serviceRepoB = new SupabaseProblemRepository(SERVICE_ROLE_MARKER);
     const original = await serviceRepoB.create({
-      namespaceId,
+      namespaceId: TEST_NAMESPACE_ID,
       title: 'Original Problem by B',
       description: 'A test description',
       starterCode: 'def solve(): pass',
@@ -120,7 +142,6 @@ describeIfSupabase('Problem duplicate() — ownership transfer + RLS editability
       classId,
       tags: ['integration', 'test'],
     });
-    createdProblemIds.push(original.id);
 
     // --- Act: sign in as A, then duplicate through A's RLS-scoped token ---
     // The real route calls storage.problems.duplicate(id, newTitle, user.id) with the
@@ -128,7 +149,7 @@ describeIfSupabase('Problem duplicate() — ownership transfer + RLS editability
     // in as A, build a SupabaseProblemRepository from A's token, then call duplicate()
     // through it. This exercises the real getById SELECT + INSERT under RLS (the
     // problems_insert policy requires is_instructor_or_higher() AND namespace_id =
-    // get_user_namespace_id() — A is an instructor in 'default', so it must pass).
+    // get_user_namespace_id() — A is an instructor in TEST_NAMESPACE_ID, so it must pass).
     const { data: signInData } = await adminClient.auth.signInWithPassword({
       email: `instructor-a${TEST_EMAIL_SUFFIX}`,
       password,
@@ -140,7 +161,6 @@ describeIfSupabase('Problem duplicate() — ownership transfer + RLS editability
 
     const rlsRepoA = new SupabaseProblemRepository(signInData.session.access_token);
     const copy = await rlsRepoA.duplicate(original.id, `${original.title} (copy)`, userA.id);
-    createdProblemIds.push(copy.id);
 
     // --- Assert: ownership transferred ---
     expect(copy.authorId).toBe(userA.id);
@@ -154,7 +174,7 @@ describeIfSupabase('Problem duplicate() — ownership transfer + RLS editability
     expect(copy.testCases).toEqual(original.testCases);
     expect(copy.tags).toEqual(original.tags);
     expect(copy.classId).toBe(original.classId);
-    expect(copy.namespaceId).toBe(original.namespaceId);
+    expect(copy.namespaceId).toBe(TEST_NAMESPACE_ID);
 
     // id and timestamps are fresh
     expect(copy.id).not.toBe(original.id);

--- a/src/server/persistence/supabase/__tests__/problem-repository.test.ts
+++ b/src/server/persistence/supabase/__tests__/problem-repository.test.ts
@@ -786,16 +786,19 @@ describe('SupabaseProblemRepository', () => {
   });
 
   describe('duplicate', () => {
-    it('should duplicate a problem with new title', async () => {
+    it('should duplicate a problem with new title and use newAuthorId (not original author)', async () => {
       // First call: getById
       const getByIdSingle = jest.fn().mockResolvedValue({ data: mockProblemRow, error: null });
       const getByIdEq = jest.fn().mockReturnValue({ single: getByIdSingle });
 
-      // Second call: create (insert)
+      const newAuthorId = 'new-author-abc';
+
+      // Second call: create (insert) — duplicated row uses newAuthorId
       const duplicatedRow = {
         ...mockProblemRow,
         id: 'new-uuid-5678',
         title: 'Duplicated Problem',
+        author_id: newAuthorId,
       };
       const insertSingle = jest.fn().mockResolvedValue({ data: duplicatedRow, error: null });
       const insertSelect = jest.fn().mockReturnValue({ single: insertSingle });
@@ -815,12 +818,14 @@ describe('SupabaseProblemRepository', () => {
         }
       });
 
-      const result = await repository.duplicate(mockProblem.id, 'Duplicated Problem');
+      const result = await repository.duplicate(mockProblem.id, 'Duplicated Problem', newAuthorId);
 
       expect(result.title).toBe('Duplicated Problem');
       expect(result.id).toBe('new-uuid-5678');
       expect(result.namespaceId).toBe(mockProblem.namespaceId);
-      expect(result.authorId).toBe(mockProblem.authorId);
+      // Must be the new author, NOT the original problem's author
+      expect(result.authorId).toBe(newAuthorId);
+      expect(result.authorId).not.toBe(mockProblem.authorId);
     });
 
     it('should throw error if original problem not found', async () => {
@@ -834,7 +839,7 @@ describe('SupabaseProblemRepository', () => {
         select: jest.fn().mockReturnValue({ eq: getByIdEq }),
       });
 
-      await expect(repository.duplicate('nonexistent', 'New Title')).rejects.toThrow(
+      await expect(repository.duplicate('nonexistent', 'New Title', 'some-author-id')).rejects.toThrow(
         'Problem not found: nonexistent'
       );
     });

--- a/src/server/persistence/supabase/problem-repository.ts
+++ b/src/server/persistence/supabase/problem-repository.ts
@@ -378,7 +378,7 @@ export class SupabaseProblemRepository implements IProblemRepository {
     return data ? data.map((row) => mapRowToProblemMetadata({ ...row, author_name: row.author_id })) : [];
   }
 
-  async duplicate(id: string, newTitle: string): Promise<Problem> {
+  async duplicate(id: string, newTitle: string, newAuthorId: string): Promise<Problem> {
     // First, get the original problem
     const original = await this.getById(id);
 
@@ -386,7 +386,9 @@ export class SupabaseProblemRepository implements IProblemRepository {
       throw new Error(`Problem not found: ${id}`);
     }
 
-    // Create a copy with new title and ID
+    // Create a copy with new title, new author, and same namespace/content
+    // The author is the duplicator (newAuthorId), NOT the original author.
+    // This ensures the copy is editable by the user who duplicated it under RLS.
     const problemInput: ProblemInput = {
       namespaceId: original.namespaceId,
       title: newTitle,
@@ -394,7 +396,7 @@ export class SupabaseProblemRepository implements IProblemRepository {
       starterCode: original.starterCode,
       testCases: original.testCases,
       executionSettings: original.executionSettings,
-      authorId: original.authorId,
+      authorId: newAuthorId,
       classId: original.classId,
       tags: original.tags,
       solution: original.solution,


### PR DESCRIPTION
## Summary
Adds a **Duplicate** action to the Problem Library so an instructor can start from an existing problem instead of a blank slate. The key design point: the copy is owned by the **user who clicks Duplicate** (not the original author), so it is immediately editable by its creator under RLS.

## Changes
- **Backend** (`coding-xtz.1`): `duplicate()` gains a `newAuthorId` param and sets the copy's author to the duplicating user; new `POST /api/problems/[id]/duplicate` route (requireAuth, inline instructor|namespace-admin|system-admin check mirroring `POST /api/problems`, namespace-scoped lookup → 404 cross-namespace, title = `"<orig> (copy)"`, returns `{ problem }` 201).
- **UI** (`coding-xtz.2`): Duplicate button in `ProblemCard` (list + grid) and `handleDuplicate` in `ProblemLibrary` that POSTs then reloads the list (mirrors the existing delete flow).
- **CI** (`coding-xtz.4`): new parallel `integration-tests` job that starts Supabase and runs the `describeIfSupabase`-gated real-DB Jest tests with `SUPABASE_SECRET_KEY` set, so they actually execute instead of passing-by-skip.
- **Tests**: mocked route tests (201 / 403 student / 404 cross-ns / 401), a real-DB integration test proving ownership transfer + that the duplicator can edit the copy under real RLS, and an e2e spec for the full duplicate→edit→persist flow.

## Notable for reviewers
- The inline role check (vs `requirePermission('problem.create')`) is a deliberate choice to mirror the sibling problems routes — confirmed with the repo owner.
- The real-DB integration test runs `duplicate()` through the duplicator's RLS-scoped token (not service-role) and is self-contained (creates its own namespace + class), so it passes in fresh CI rather than depending on seed state.

## Test plan
- [x] `npm test` (3427 passed), `npm run lint`, `npx tsc --noEmit`
- [x] Real-DB integration test runs + passes with `SUPABASE_SECRET_KEY` (ownership transfer + RLS editability)
- [x] e2e `e2e/duplicate-problem.spec.ts` passes (duplicate → edit → reload → persisted)

## Manual step required
- The new `Integration Tests (real DB)` CI job must be added to **required status checks** in `main` branch protection (cannot be done from code) — see `coding-xtz.4`.

## Follow-ups (filed, deferred)
- `coding-8aa`: system-admin cross-namespace duplicate returns an opaque 500 under RLS (cross-namespace is out of scope for this epic; fails safe; consistent with sibling routes).

Beads: coding-xtz, coding-xtz.1, coding-xtz.2, coding-xtz.3, coding-xtz.4, coding-jd6, coding-gfa

Generated with Claude Code