### PR TITLE
fix(test): stop npm test hanging on exit from leaked RevisionBuffer timer

### DIFF
--- a/src/app/api/sessions/[id]/code/__tests__/route.test.ts
+++ b/src/app/api/sessions/[id]/code/__tests__/route.test.ts
@@ -9,7 +9,8 @@ import { NextRequest } from 'next/server';
 import { POST } from '../route';
 import { getAuthenticatedUserWithToken } from '@/server/auth/api-auth';
 import { createStorage } from '@/server/persistence';
-import { revisionBufferHolder } from '@/server/revision-buffer';
+import { revisionBufferHolder, RevisionBuffer } from '@/server/revision-buffer';
+import * as RevisionBufferModule from '@/server/revision-buffer';
 import * as SessionService from '@/server/services/session-service';
 import { Session } from '@/server/types';
 import { Problem } from '@/server/types/problem';
@@ -117,6 +118,14 @@ describe('POST /api/sessions/[id]/code', () => {
   });
 
   afterEach(() => {
+    // If a test left a REAL RevisionBuffer in the holder, stop its 30s
+    // auto-flush setInterval. That timer is not unref'd, so an orphaned buffer
+    // keeps the Node event loop (and Jest) alive — which hangs `npm test` when
+    // Jest runs in-band (maxWorkers=1, e.g. on <=2-CPU hosts) instead of in a
+    // worker process that would be killed on completion.
+    if (revisionBufferHolder.instance instanceof RevisionBuffer) {
+      revisionBufferHolder.instance.stopAutoFlush();
+    }
     revisionBufferHolder.instance = null;
   });
 
@@ -315,6 +324,13 @@ describe('POST /api/sessions/[id]/code', () => {
 
   it('works without revision buffer', async () => {
     revisionBufferHolder.instance = null;
+    // Stub the lazy-init path so the route does NOT construct a real
+    // RevisionBuffer (which would arm a leaked 30s setInterval + a 5s
+    // typing-pause setTimeout and hit a real repository). We only need to
+    // verify the route still succeeds when the holder starts empty.
+    const getBufferSpy = jest
+      .spyOn(RevisionBufferModule, 'getRevisionBuffer')
+      .mockResolvedValue({ addRevision: jest.fn().mockResolvedValue(undefined) } as unknown as RevisionBuffer);
     mockGetAuthenticatedUserWithToken.mockResolvedValue({ user: mockUser, accessToken: 'test-token' });
 
     const request = new NextRequest('http://localhost:3000/api/sessions/session-1/code', {
@@ -326,6 +342,8 @@ describe('POST /api/sessions/[id]/code', () => {
     const response = await POST(request, { params });
 
     expect(response.status).toBe(200);
+    expect(getBufferSpy).toHaveBeenCalled();
+    getBufferSpy.mockRestore();
   });
 
   it('returns 500 when service fails', async () => {


### PR DESCRIPTION
## Summary
- `npm test` completed every suite but then **never exited** on hosts where Jest runs in-band (`maxWorkers=1`, i.e. ≤2-CPU machines such as the devcontainer), appearing to hang.
- Root cause is a test-hygiene bug, not the environment: the `'works without revision buffer'` test in the code-route suite nulls `revisionBufferHolder.instance`, so the route lazily constructs a **real** `RevisionBuffer` whose `startAutoFlush()` arms a non-`unref`'d 30s `setInterval`. `afterEach` then reset the holder to `null` without `stopAutoFlush()`, orphaning the buffer with a live timer that keeps the Node event loop alive.
- Why it looked environment-specific: with ≥3 CPUs Jest forks a worker process that it kills on completion, taking the leaked timer with it and hiding the leak. With ≤2 CPUs Jest runs in-band in the main process, so the timer hangs `npm test`. `--detectOpenHandles` does not surface it.

## Changes
- Stub `getRevisionBuffer` in the offending test so no real buffer/timer/repository is constructed; the test still verifies the route succeeds when the holder starts empty.
- Defensively `stopAutoFlush()` any real `RevisionBuffer` left in the holder during `afterEach`, guarding against future reintroduction.

## Test plan
- [x] Affected suite passes in-band (`--runInBand`), 18/18
- [x] Full server project passes in-band and **exits cleanly** (previously hung)
- [x] Full `npm test` (both projects, 3437 tests) ran via the pre-push hook in-band and exited cleanly in 89s

Beads: coding-7kn

Generated with Claude Code