### PR TITLE
feat: instructors can duplicate a problem (build off / port between classes)

### DIFF
--- a/e2e/problem-duplication.spec.ts
+++ b/e2e/problem-duplication.spec.ts
@@ -1,0 +1,185 @@
+import { test, expect } from './helpers/setup';
+import { hasSupabaseCredentials } from './helpers/db-helpers';
+import {
+  loginAsInstructor,
+  generateTestNamespaceId,
+  createTestNamespace,
+  cleanupNamespace,
+} from './fixtures/auth-helpers';
+import {
+  getSupabaseAdmin,
+  createTestClass,
+  createTestProblem,
+} from './helpers/test-data';
+
+/**
+ * Problem Duplication E2E Tests
+ *
+ * Epic-level acceptance tests for instructor problem duplication (coding-33o).
+ * Covers the full "Duplicate button → modal → POST /api/problems/[id]/duplicate → list refresh"
+ * flow for two scenarios:
+ *   1. Same-class build-off: copy lands in the same class, instructor can edit it.
+ *   2. Cross-class port: copy lands in a different class the instructor owns.
+ *
+ * These tests require a running local Supabase instance (SUPABASE_SECRET_KEY set).
+ * They skip automatically when credentials are absent.
+ */
+
+const describeE2E = hasSupabaseCredentials() ? test.describe : test.describe.skip;
+
+const PROBLEM_TITLE = 'Binary Search';
+const COPY_TITLE = `Copy of ${PROBLEM_TITLE}`;
+
+describeE2E('Problem Duplication', () => {
+  test('same-class build-off: instructor duplicates a problem, copy is editable', async ({ page }) => {
+    /**
+     * Verifies the complete same-class duplication flow:
+     * - "Duplicate" button is present on the problem card
+     * - Modal pre-fills the title as "Copy of <title>"
+     * - Default target is "Same class (default)"
+     * - On confirm: POST succeeds, modal closes, library refreshes with "Copy of <title>"
+     * - The copy is editable by the instructor (authorId set to instructor.id → RLS allows edit)
+     *
+     * Catches: route not setting authorId to current user (RLS blocks edit); modal not wired;
+     * list not refreshed after duplication; Duplicate button missing from card.
+     */
+    test.setTimeout(60000);
+
+    const namespaceId = generateTestNamespaceId();
+    await createTestNamespace(namespaceId);
+
+    try {
+      // Login first — we need the instructor's user ID to set up owned data.
+      const instructor = await loginAsInstructor(page, `instructor-${namespaceId}`, namespaceId);
+
+      // Set up class A and a problem authored by the instructor, bypassing UI.
+      const supabase = getSupabaseAdmin();
+      const classA = await createTestClass(supabase, namespaceId, instructor.id, 'Class A');
+      await createTestProblem(supabase, {
+        classId: classA.id,
+        namespaceId,
+        authorId: instructor.id,
+        title: PROBLEM_TITLE,
+      });
+
+      // Navigate to the problem library (separate page from the dashboard).
+      await page.goto('/instructor/problems');
+
+      // Wait for the class picker to load, then select class A.
+      await expect(page.locator('select#class-picker')).toBeVisible({ timeout: 15000 });
+      await page.selectOption('select#class-picker', classA.id);
+
+      // Wait for the problem to appear in the list.
+      await expect(page.locator(`h3:has-text("${PROBLEM_TITLE}")`)).toBeVisible({ timeout: 15000 });
+
+      // Click the Duplicate button on the problem card (list-view button has title="Duplicate problem").
+      await page.locator('button[title="Duplicate problem"]').first().click();
+
+      // The DuplicateProblemModal should open.
+      await expect(page.locator('h2:has-text("Duplicate Problem")')).toBeVisible({ timeout: 5000 });
+
+      // Title input must be pre-filled with "Copy of <original title>".
+      await expect(page.locator('input#duplicate-title')).toHaveValue(COPY_TITLE);
+
+      // Target class defaults to "Same class (default)" — value is '' (empty string).
+      await expect(page.locator('select#duplicate-target-class')).toHaveValue('');
+
+      // Confirm the duplication.
+      // The modal's submit button is the last "Duplicate" button in DOM order
+      // (the modal is rendered after all ProblemCard components in ProblemLibrary).
+      await page.locator('button:has-text("Duplicate")').last().click();
+
+      // Modal must close after success.
+      await expect(page.locator('h2:has-text("Duplicate Problem")')).not.toBeVisible({ timeout: 15000 });
+
+      // The copy must appear in the library (list refreshes after onSuccess).
+      await expect(page.locator(`h3:has-text("${COPY_TITLE}")`)).toBeVisible({ timeout: 15000 });
+
+      // Click Edit on the copy to verify it is editable.
+      // Problems are sorted by creation date descending; the copy (newest) appears first.
+      await page.locator('button[title="Edit problem"]').first().click();
+
+      // URL changes to /instructor/problems?edit=<copyId> (ProblemCreator renders).
+      await expect(page).toHaveURL(/\/instructor\/problems\?edit=/, { timeout: 10000 });
+
+      // Wait for the problem to load in the editor (tabs only render when !isLoading).
+      // "Starter Code" tab presence proves: no load error, copy was readable, editor is live.
+      await expect(page.getByRole('tab', { name: 'Starter Code' })).toBeVisible({ timeout: 15000 });
+
+      // No error message must appear (which would indicate a permissions/RLS failure).
+      await expect(page.locator('text=Failed to load problem')).not.toBeVisible();
+    } finally {
+      await cleanupNamespace(namespaceId);
+    }
+  });
+
+  test('cross-class port: instructor duplicates a problem to another class they own', async ({ page }) => {
+    /**
+     * Verifies the cross-class duplication flow:
+     * - Instructor selects a different target class in the modal
+     * - On confirm: copy appears under the target class filter
+     * - Original remains in the source class
+     *
+     * Catches: targetClassId override not applied (copy lands in wrong class);
+     * target-class auth check wrongly blocking an instructor-owned class;
+     * original deleted or moved instead of copied.
+     */
+    test.setTimeout(60000);
+
+    const namespaceId = generateTestNamespaceId();
+    await createTestNamespace(namespaceId);
+
+    try {
+      const instructor = await loginAsInstructor(page, `instructor-${namespaceId}`, namespaceId);
+
+      const supabase = getSupabaseAdmin();
+
+      // Two classes, both owned by the instructor (created_by = instructor.id),
+      // so the target-class ownership check in the API route will pass for class B.
+      const classA = await createTestClass(supabase, namespaceId, instructor.id, 'Class A');
+      const classB = await createTestClass(supabase, namespaceId, instructor.id, 'Class B');
+      await createTestProblem(supabase, {
+        classId: classA.id,
+        namespaceId,
+        authorId: instructor.id,
+        title: PROBLEM_TITLE,
+      });
+
+      await page.goto('/instructor/problems');
+
+      // Select class A and wait for the problem to load.
+      await expect(page.locator('select#class-picker')).toBeVisible({ timeout: 15000 });
+      await page.selectOption('select#class-picker', classA.id);
+      await expect(page.locator(`h3:has-text("${PROBLEM_TITLE}")`)).toBeVisible({ timeout: 15000 });
+
+      // Open the duplicate modal.
+      await page.locator('button[title="Duplicate problem"]').first().click();
+      await expect(page.locator('h2:has-text("Duplicate Problem")')).toBeVisible({ timeout: 5000 });
+
+      // Select class B as the target.
+      // The modal's select is populated from the instructor's class list loaded by ProblemLibrary.
+      await page.selectOption('select#duplicate-target-class', classB.id);
+
+      // Confirm.
+      await page.locator('button:has-text("Duplicate")').last().click();
+
+      // Modal closes (copy was created in class B, library refreshes class A — copy absent there).
+      await expect(page.locator('h2:has-text("Duplicate Problem")')).not.toBeVisible({ timeout: 15000 });
+
+      // Switch the library filter to class B — the copy must appear.
+      await page.selectOption('select#class-picker', classB.id);
+      await expect(page.locator(`h3:has-text("${COPY_TITLE}")`)).toBeVisible({ timeout: 15000 });
+
+      // Switch back to class A — the original must still be there, copy must NOT be.
+      await page.selectOption('select#class-picker', classA.id);
+
+      // Wait for class A problems to load (original appears to confirm the list updated).
+      await expect(page.getByRole('heading', { name: PROBLEM_TITLE, exact: true, level: 3 })).toBeVisible({ timeout: 15000 });
+
+      // Copy must not be listed under class A.
+      await expect(page.getByRole('heading', { name: COPY_TITLE, exact: true, level: 3 })).not.toBeVisible();
+    } finally {
+      await cleanupNamespace(namespaceId);
+    }
+  });
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -5,6 +5,13 @@ import path from 'path';
 // Load environment variables from .env.local
 dotenv.config({ path: path.resolve(__dirname, '.env.local') });
 
+// Support PORT override so worktree dev servers can run on a non-default port
+// without colliding with a main-branch server already listening on 3000.
+// Usage: PORT=3001 npm run test:e2e
+// When PORT is unset, behaviour is unchanged: use 3000 and reuse any running server.
+const serverPort = process.env.PORT || '3000';
+const serverUrl = `http://localhost:${serverPort}`;
+
 /**
  * Playwright configuration for E2E testing
  * See https://playwright.dev/docs/test-configuration
@@ -33,7 +40,7 @@ export default defineConfig({
   /* Shared settings for all the projects below */
   use: {
     /* Base URL to use in actions like `await page.goto('/')` */
-    baseURL: 'http://localhost:3000',
+    baseURL: serverUrl,
 
     /* Collect trace when retrying the failed test */
     trace: 'on-first-retry',
@@ -57,12 +64,13 @@ export default defineConfig({
   webServer: {
     // Use production build in CI for stability, dev mode locally for speed
     command: process.env.CI ? 'npm run build && npm start' : 'npm run dev',
-    url: 'http://localhost:3000',
+    url: serverUrl,
     reuseExistingServer: !process.env.CI,
     timeout: 120 * 1000, // 2 minutes to start
     // Pass environment variables to the dev server subprocess
     env: {
       ...process.env,
+      PORT: serverPort,
       NEXT_PUBLIC_SUPABASE_URL: process.env.NEXT_PUBLIC_SUPABASE_URL || 'http://127.0.0.1:54321',
       NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY || '',
       SUPABASE_SECRET_KEY: process.env.SUPABASE_SECRET_KEY || '',

--- a/src/app/(app)/instructor/components/DuplicateProblemModal.tsx
+++ b/src/app/(app)/instructor/components/DuplicateProblemModal.tsx
@@ -1,0 +1,149 @@
+'use client';
+
+/**
+ * DuplicateProblemModal
+ *
+ * Opens when an instructor clicks "Duplicate" on a problem card.
+ * Lets the instructor edit the copy title and optionally pick a target class.
+ * POSTs to /api/problems/{id}/duplicate then calls onSuccess + onClose.
+ */
+
+import React, { useState } from 'react';
+
+interface DuplicateProblemModalProps {
+  problem: { id: string; title: string; classId: string };
+  classes: Array<{ id: string; name: string }>;
+  onClose: () => void;
+  onSuccess: () => void;
+}
+
+export default function DuplicateProblemModal({
+  problem,
+  classes,
+  onClose,
+  onSuccess,
+}: DuplicateProblemModalProps) {
+  const [title, setTitle] = useState(`Copy of ${problem.title}`);
+  const [targetClassId, setTargetClassId] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async () => {
+    try {
+      setLoading(true);
+      setError(null);
+
+      const body: { title: string; targetClassId?: string } = {
+        title: title.trim(),
+        ...(targetClassId ? { targetClassId } : {}),
+      };
+
+      const response = await fetch(`/api/problems/${problem.id}/duplicate`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+
+      if (!response.ok) {
+        const data = await response.json();
+        throw new Error(data.error || 'Failed to duplicate problem');
+      }
+
+      onSuccess();
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to duplicate problem');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+      <div className="bg-white rounded-lg shadow-xl max-w-md w-full p-6">
+        {/* Header */}
+        <div className="flex justify-between items-start mb-4">
+          <div>
+            <h2 className="text-xl font-bold text-gray-900">Duplicate Problem</h2>
+            <p className="text-sm text-gray-600 mt-1">
+              Original: <span className="font-medium">{problem.title}</span>
+            </p>
+          </div>
+          <button
+            onClick={onClose}
+            className="text-gray-400 hover:text-gray-600 transition-colors"
+            disabled={loading}
+            aria-label="Close"
+          >
+            <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        {/* Error */}
+        {error && (
+          <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded-lg text-red-700 text-sm">
+            {error}
+          </div>
+        )}
+
+        <div className="space-y-4">
+          {/* Title */}
+          <div>
+            <label htmlFor="duplicate-title" className="block text-sm font-medium text-gray-700 mb-2">
+              Title
+            </label>
+            <input
+              id="duplicate-title"
+              type="text"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+              disabled={loading}
+            />
+          </div>
+
+          {/* Target class */}
+          <div>
+            <label htmlFor="duplicate-target-class" className="block text-sm font-medium text-gray-700 mb-2">
+              Target Class
+            </label>
+            <select
+              id="duplicate-target-class"
+              value={targetClassId}
+              onChange={(e) => setTargetClassId(e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+              disabled={loading}
+            >
+              <option value="">Same class (default)</option>
+              {classes.map((c) => (
+                <option key={c.id} value={c.id}>
+                  {c.name}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+
+        {/* Actions */}
+        <div className="flex gap-3 mt-6">
+          <button
+            onClick={onClose}
+            className="flex-1 px-4 py-2 border border-gray-300 text-gray-700 rounded-md hover:bg-gray-50 transition-colors"
+            disabled={loading}
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleSubmit}
+            disabled={loading}
+            className="flex-1 px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          >
+            {loading ? 'Duplicating...' : 'Duplicate'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(app)/instructor/components/ProblemCard.tsx
+++ b/src/app/(app)/instructor/components/ProblemCard.tsx
@@ -19,6 +19,7 @@ interface ProblemCardProps {
   onDelete: (problemId: string, title: string) => void;
   onCreateSession: (problemId: string) => void;
   onTagClick?: (tag: string) => void;
+  onDuplicate?: (problemId: string) => void;
 }
 
 export default function ProblemCard({
@@ -28,6 +29,7 @@ export default function ProblemCard({
   onDelete,
   onCreateSession,
   onTagClick,
+  onDuplicate,
 }: ProblemCardProps) {
   const [isDeleting, setIsDeleting] = useState(false);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
@@ -123,6 +125,15 @@ export default function ProblemCard({
             >
               {isDeleting ? '...' : 'Delete'}
             </button>
+            {onDuplicate && (
+              <button
+                onClick={() => onDuplicate(problem.id)}
+                className="px-3 py-1.5 text-sm text-gray-600 hover:bg-gray-100 rounded-lg transition-colors"
+                title="Duplicate problem"
+              >
+                Duplicate
+              </button>
+            )}
           </div>
         </div>
         <ConfirmDialog
@@ -180,6 +191,14 @@ export default function ProblemCard({
         >
           {isDeleting ? 'Deleting...' : 'Delete'}
         </button>
+        {onDuplicate && (
+          <button
+            onClick={() => onDuplicate(problem.id)}
+            className="col-span-2 px-3 py-2 text-sm text-gray-600 border border-gray-300 hover:bg-gray-100 rounded-lg transition-colors"
+          >
+            Duplicate
+          </button>
+        )}
       </div>
       <ConfirmDialog
         open={showDeleteConfirm}

--- a/src/app/(app)/instructor/components/ProblemCard.tsx
+++ b/src/app/(app)/instructor/components/ProblemCard.tsx
@@ -195,6 +195,7 @@ export default function ProblemCard({
           <button
             onClick={() => onDuplicate(problem.id)}
             className="col-span-2 px-3 py-2 text-sm text-gray-600 border border-gray-300 hover:bg-gray-100 rounded-lg transition-colors"
+            title="Duplicate problem"
           >
             Duplicate
           </button>

--- a/src/app/(app)/instructor/components/ProblemLibrary.tsx
+++ b/src/app/(app)/instructor/components/ProblemLibrary.tsx
@@ -12,6 +12,7 @@ import { useRouter } from 'next/navigation';
 import ProblemSearch from './ProblemSearch';
 import ProblemCard from './ProblemCard';
 import CreateSessionFromProblemModal from './CreateSessionFromProblemModal';
+import DuplicateProblemModal from './DuplicateProblemModal';
 import type { ClassInfo, ProblemSummary } from '../types';
 
 interface ProblemLibraryProps {
@@ -41,6 +42,9 @@ export default function ProblemLibrary({ onCreateNew, onEdit }: ProblemLibraryPr
   // Session creation modal state
   const [showSessionModal, setShowSessionModal] = useState(false);
   const [selectedProblemForSession, setSelectedProblemForSession] = useState<{ id: string; title: string; classId: string } | null>(null);
+
+  // Duplicate modal state
+  const [duplicatingProblem, setDuplicatingProblem] = useState<{ id: string; title: string; classId: string } | null>(null);
 
   // Load classes on mount
   useEffect(() => {
@@ -225,6 +229,20 @@ export default function ProblemLibrary({ onCreateNew, onEdit }: ProblemLibraryPr
     setSelectedProblemForSession(null);
   };
 
+  const handleDuplicate = (problemId: string) => {
+    const problem = problems.find(p => p.id === problemId);
+    if (!problem) return;
+    setDuplicatingProblem({ id: problem.id, title: problem.title, classId: problem.classId });
+  };
+
+  const handleDuplicateSuccess = () => {
+    loadProblems();
+  };
+
+  const handleCloseDuplicateModal = () => {
+    setDuplicatingProblem(null);
+  };
+
   if (loading) {
     return (
       <div className="flex justify-center items-center py-12">
@@ -351,6 +369,7 @@ export default function ProblemLibrary({ onCreateNew, onEdit }: ProblemLibraryPr
               onDelete={handleDelete}
               onCreateSession={handleCreateSession}
               onTagClick={handleTagToggle}
+              onDuplicate={handleDuplicate}
             />
           ))}
         </div>
@@ -365,6 +384,16 @@ export default function ProblemLibrary({ onCreateNew, onEdit }: ProblemLibraryPr
           className={classes.find(c => c.id === selectedProblemForSession.classId)?.name || ''}
           onClose={handleCloseSessionModal}
           onSuccess={handleSessionCreated}
+        />
+      )}
+
+      {/* Duplicate Problem Modal */}
+      {duplicatingProblem && (
+        <DuplicateProblemModal
+          problem={duplicatingProblem}
+          classes={classes}
+          onClose={handleCloseDuplicateModal}
+          onSuccess={handleDuplicateSuccess}
         />
       )}
     </div>

--- a/src/app/(app)/instructor/components/__tests__/DuplicateProblemModal.test.tsx
+++ b/src/app/(app)/instructor/components/__tests__/DuplicateProblemModal.test.tsx
@@ -1,0 +1,198 @@
+/**
+ * Tests for DuplicateProblemModal component.
+ *
+ * Contract: the modal prefills the title as 'Copy of <original>', lists all
+ * provided classes plus a default 'Same class' option, and POSTs to
+ * /api/problems/{id}/duplicate with body { title, targetClassId? } where
+ * targetClassId is omitted when the user leaves the dropdown on default.
+ * On success it calls onSuccess then onClose. On error it shows the
+ * server-returned message.
+ *
+ * Why it matters: wrong endpoint, wrong body shape (e.g. sending
+ * targetClassId='' instead of omitting the key), missing prefill, or
+ * swallowed errors would silently break the feature or cause 400/403
+ * responses from the server.
+ *
+ * @jest-environment jsdom
+ */
+
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import DuplicateProblemModal from '../DuplicateProblemModal';
+
+const problem = { id: 'p1', title: 'Loops', classId: 'A' };
+const classes = [
+  { id: 'A', name: 'CS101' },
+  { id: 'B', name: 'CS102' },
+];
+
+const defaultProps = {
+  problem,
+  classes,
+  onClose: jest.fn(),
+  onSuccess: jest.fn(),
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  global.fetch = jest.fn();
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('DuplicateProblemModal – initial render', () => {
+  it('prefills the title input with "Copy of <original title>"', () => {
+    render(<DuplicateProblemModal {...defaultProps} />);
+    const input = screen.getByRole('textbox', { name: /title/i });
+    expect(input).toHaveValue('Copy of Loops');
+  });
+
+  it('shows a default "Same class" option in the target-class dropdown', () => {
+    render(<DuplicateProblemModal {...defaultProps} />);
+    expect(screen.getByRole('option', { name: /same class/i })).toBeInTheDocument();
+  });
+
+  it('lists all provided classes as dropdown options', () => {
+    render(<DuplicateProblemModal {...defaultProps} />);
+    expect(screen.getByRole('option', { name: 'CS101' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'CS102' })).toBeInTheDocument();
+  });
+
+  it('defaults the target-class dropdown to the same-class value (empty string)', () => {
+    render(<DuplicateProblemModal {...defaultProps} />);
+    const select = screen.getByRole('combobox');
+    expect(select).toHaveValue('');
+  });
+});
+
+describe('DuplicateProblemModal – submitting with a target class', () => {
+  it('POSTs to the correct endpoint with title and targetClassId when a class is selected', async () => {
+    /**
+     * Verifies the full request: URL, method, and body all match the endpoint
+     * contract. A wrong endpoint or missing targetClassId would create the
+     * duplicate in the wrong class without any visible error.
+     */
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ problem: { id: 'new-p' } }),
+    });
+
+    render(<DuplicateProblemModal {...defaultProps} />);
+
+    // Pick class B
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'B' } });
+    fireEvent.click(screen.getByRole('button', { name: /duplicate/i }));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        '/api/problems/p1/duplicate',
+        expect.objectContaining({
+          method: 'POST',
+          headers: expect.objectContaining({ 'Content-Type': 'application/json' }),
+          body: JSON.stringify({ title: 'Copy of Loops', targetClassId: 'B' }),
+        })
+      );
+    });
+  });
+
+  it('calls onSuccess then onClose after a successful POST', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ problem: { id: 'new-p' } }),
+    });
+
+    render(<DuplicateProblemModal {...defaultProps} />);
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'B' } });
+    fireEvent.click(screen.getByRole('button', { name: /duplicate/i }));
+
+    await waitFor(() => {
+      expect(defaultProps.onSuccess).toHaveBeenCalledTimes(1);
+      expect(defaultProps.onClose).toHaveBeenCalledTimes(1);
+    });
+  });
+});
+
+describe('DuplicateProblemModal – submitting without a target class (same class)', () => {
+  it('POSTs without a targetClassId key when "Same class" is selected', async () => {
+    /**
+     * Verifies that targetClassId is omitted (not sent as '') when the user
+     * leaves the dropdown at default. Sending targetClassId='' would produce
+     * a 400 from the server (empty string is not a valid UUID).
+     */
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ problem: { id: 'new-p' } }),
+    });
+
+    render(<DuplicateProblemModal {...defaultProps} />);
+    // Leave dropdown at default (same class)
+    fireEvent.click(screen.getByRole('button', { name: /duplicate/i }));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    const callArgs = (global.fetch as jest.Mock).mock.calls[0];
+    const body = JSON.parse(callArgs[1].body);
+    expect(body).not.toHaveProperty('targetClassId');
+    expect(body.title).toBe('Copy of Loops');
+  });
+});
+
+describe('DuplicateProblemModal – error handling', () => {
+  it('shows an error message from the server when the response is not ok', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: false,
+      json: async () => ({ error: 'Title cannot be blank' }),
+    });
+
+    render(<DuplicateProblemModal {...defaultProps} />);
+    // Clear the title to trigger server error scenario
+    fireEvent.change(screen.getByRole('textbox', { name: /title/i }), {
+      target: { value: '  ' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /duplicate/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Title cannot be blank')).toBeInTheDocument();
+    });
+
+    // Modal should remain open
+    expect(defaultProps.onClose).not.toHaveBeenCalled();
+    expect(defaultProps.onSuccess).not.toHaveBeenCalled();
+  });
+
+  it('disables the submit button while the request is in flight', async () => {
+    let resolveRequest!: (value: unknown) => void;
+    (global.fetch as jest.Mock).mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveRequest = resolve;
+      })
+    );
+
+    render(<DuplicateProblemModal {...defaultProps} />);
+    const submitBtn = screen.getByRole('button', { name: /duplicate/i });
+
+    fireEvent.click(submitBtn);
+
+    // Button should be disabled while pending
+    expect(submitBtn).toBeDisabled();
+
+    // Resolve the request
+    resolveRequest({ ok: true, json: async () => ({ problem: { id: 'new' } }) });
+
+    await waitFor(() => {
+      expect(defaultProps.onSuccess).toHaveBeenCalled();
+    });
+  });
+});
+
+describe('DuplicateProblemModal – close', () => {
+  it('calls onClose when the Cancel button is clicked', () => {
+    render(<DuplicateProblemModal {...defaultProps} />);
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+    expect(defaultProps.onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/app/(app)/instructor/components/__tests__/ProblemCard.duplicate.test.tsx
+++ b/src/app/(app)/instructor/components/__tests__/ProblemCard.duplicate.test.tsx
@@ -1,0 +1,82 @@
+/**
+ * Tests for ProblemCard Duplicate button behavior.
+ *
+ * Contract: ProblemCard accepts an optional onDuplicate prop and renders a
+ * 'Duplicate' button in both list and grid views. Clicking it calls
+ * onDuplicate(problem.id). When the prop is omitted the button is absent.
+ *
+ * Why it matters: if the button is missing, wired to the wrong callback,
+ * or passes the wrong id, the modal will never open or will operate on
+ * the wrong problem.
+ *
+ * @jest-environment jsdom
+ */
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import ProblemCard from '../ProblemCard';
+
+const mockProblem = {
+  id: 'problem-123',
+  title: 'Loops',
+  description: 'A problem about loops',
+  createdAt: '2025-01-01T00:00:00.000Z',
+  authorId: 'user-1',
+  tags: [],
+  classId: 'class-A',
+};
+
+const baseProps = {
+  problem: mockProblem,
+  viewMode: 'list' as const,
+  onEdit: jest.fn(),
+  onDelete: jest.fn(),
+  onCreateSession: jest.fn(),
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('ProblemCard – Duplicate button (list view)', () => {
+  it('renders a Duplicate button when onDuplicate is provided', () => {
+    const onDuplicate = jest.fn();
+    render(<ProblemCard {...baseProps} onDuplicate={onDuplicate} />);
+    expect(screen.getByRole('button', { name: /duplicate/i })).toBeInTheDocument();
+  });
+
+  it('calls onDuplicate with the problem id when clicked', () => {
+    const onDuplicate = jest.fn();
+    render(<ProblemCard {...baseProps} onDuplicate={onDuplicate} />);
+    fireEvent.click(screen.getByRole('button', { name: /duplicate/i }));
+    expect(onDuplicate).toHaveBeenCalledTimes(1);
+    expect(onDuplicate).toHaveBeenCalledWith('problem-123');
+  });
+
+  it('does not render a Duplicate button when onDuplicate is omitted', () => {
+    render(<ProblemCard {...baseProps} />);
+    expect(screen.queryByRole('button', { name: /duplicate/i })).not.toBeInTheDocument();
+  });
+});
+
+describe('ProblemCard – Duplicate button (grid view)', () => {
+  const gridProps = { ...baseProps, viewMode: 'grid' as const };
+
+  it('renders a Duplicate button in grid view when onDuplicate is provided', () => {
+    const onDuplicate = jest.fn();
+    render(<ProblemCard {...gridProps} onDuplicate={onDuplicate} />);
+    expect(screen.getByRole('button', { name: /duplicate/i })).toBeInTheDocument();
+  });
+
+  it('calls onDuplicate with the problem id in grid view', () => {
+    const onDuplicate = jest.fn();
+    render(<ProblemCard {...gridProps} onDuplicate={onDuplicate} />);
+    fireEvent.click(screen.getByRole('button', { name: /duplicate/i }));
+    expect(onDuplicate).toHaveBeenCalledWith('problem-123');
+  });
+
+  it('does not render a Duplicate button in grid view when onDuplicate is omitted', () => {
+    render(<ProblemCard {...gridProps} />);
+    expect(screen.queryByRole('button', { name: /duplicate/i })).not.toBeInTheDocument();
+  });
+});

--- a/src/app/(app)/instructor/components/__tests__/ProblemLibrary.test.tsx
+++ b/src/app/(app)/instructor/components/__tests__/ProblemLibrary.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from 'react';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
 import ProblemLibrary from '../ProblemLibrary';
 import { useAuth } from '@/contexts/AuthContext';
 
@@ -40,6 +40,7 @@ jest.mock('../ProblemCard', () => {
         {props.problem.title}
         <button data-testid={`edit-${props.problem.id}`} onClick={() => props.onEdit(props.problem.id)}>Edit</button>
         <button data-testid={`create-session-${props.problem.id}`} onClick={() => props.onCreateSession(props.problem.id)}>Create Session</button>
+        <button data-testid={`duplicate-${props.problem.id}`} onClick={() => props.onDuplicate && props.onDuplicate(props.problem.id)}>Duplicate</button>
       </div>
     );
   };
@@ -423,6 +424,118 @@ describe('ProblemLibrary', () => {
 
       await waitFor(() => {
         expect(screen.getByTestId('problem-search')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('Duplicate handler', () => {
+    /**
+     * These tests cover the handleDuplicate → DuplicateProblemModal wiring in ProblemLibrary:
+     * clicking Duplicate on a card opens the modal prefilled with 'Copy of <title>', and a
+     * successful POST triggers handleDuplicateSuccess → loadProblems. This covers a wiring gap
+     * that was only in e2e tests (which skip in CI without SUPABASE_SECRET_KEY).
+     */
+
+    const mockClasses = [{ id: 'class-1', name: 'CS 101', namespaceId: 'ns-1' }];
+
+    beforeEach(() => {
+      global.fetch = jest.fn((url: string, _opts?: RequestInit) => {
+        if (typeof url === 'string' && url.includes('/api/classes')) {
+          return Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve({ classes: mockClasses }),
+          });
+        }
+        if (typeof url === 'string' && url.includes('/duplicate')) {
+          return Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve({ problem: { id: 'problem-copy', title: 'Copy of Problem 1' } }),
+          });
+        }
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ problems: mockProblems }),
+        });
+      }) as jest.Mock;
+    });
+
+    it('opens DuplicateProblemModal prefilled with "Copy of <title>" when Duplicate is clicked', async () => {
+      /**
+       * Verifies the handleDuplicate wiring: the clicked problem is looked up by id from
+       * the loaded problems list, and DuplicateProblemModal is rendered with that problem.
+       * The modal's own logic prefills "Copy of <title>" — asserting that value proves both
+       * the lookup and the prop handoff are correct.
+       * Catches: wrong problem selected; missing classId on prop; modal not rendered at all.
+       */
+      render(<ProblemLibrary />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('duplicate-problem-1')).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByTestId('duplicate-problem-1'));
+
+      await waitFor(() => {
+        const titleInput = screen.getByRole('textbox', { name: /title/i });
+        expect(titleInput).toHaveValue('Copy of Problem 1');
+      });
+    });
+
+    it('reloads the problem list after a successful duplicate', async () => {
+      /**
+       * Verifies that handleDuplicateSuccess calls loadProblems so the new copy
+       * appears without a manual page refresh.
+       * Catches: missing onSuccess→loadProblems wiring; problems state not refreshed.
+       */
+      let problemsFetchCount = 0;
+      global.fetch = jest.fn((url: string, _opts?: RequestInit) => {
+        if (typeof url === 'string' && url.includes('/api/classes')) {
+          return Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve({ classes: mockClasses }),
+          });
+        }
+        if (typeof url === 'string' && url.includes('/duplicate')) {
+          return Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve({ problem: { id: 'problem-copy', title: 'Copy of Problem 1' } }),
+          });
+        }
+        // /api/problems
+        problemsFetchCount++;
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ problems: mockProblems }),
+        });
+      }) as jest.Mock;
+
+      render(<ProblemLibrary />);
+
+      // Wait for initial load
+      await waitFor(() => {
+        expect(screen.getByTestId('duplicate-problem-1')).toBeInTheDocument();
+      });
+
+      const countAfterLoad = problemsFetchCount;
+
+      // Open modal
+      fireEvent.click(screen.getByTestId('duplicate-problem-1'));
+
+      await waitFor(() => {
+        expect(screen.getByRole('textbox', { name: /title/i })).toBeInTheDocument();
+      });
+
+      // Submit the duplicate form (default same-class, prefilled title).
+      // Scope to the modal (heading "Duplicate Problem") because the mocked
+      // ProblemCard also renders per-card "Duplicate" buttons.
+      const modal = screen
+        .getByRole('heading', { name: 'Duplicate Problem' })
+        .closest('div.fixed') as HTMLElement;
+      fireEvent.click(within(modal).getByRole('button', { name: /^duplicate$/i }));
+
+      // After success, loadProblems must be called again
+      await waitFor(() => {
+        expect(problemsFetchCount).toBeGreaterThan(countAfterLoad);
       });
     });
   });

--- a/src/app/api/problems/[id]/duplicate/__tests__/route.test.ts
+++ b/src/app/api/problems/[id]/duplicate/__tests__/route.test.ts
@@ -1,0 +1,373 @@
+/**
+ * Tests for POST /api/problems/[id]/duplicate
+ *
+ * Tests:
+ * - Authentication via requirePermission('problem.create')
+ * - 401/403 from auth gate (unauthenticated, student)
+ * - 400 for blank title
+ * - 404 for unknown source problem
+ * - 404 for unknown target class
+ * - 403 for target class not owned by instructor
+ * - 201 same-class duplicate (no targetClassId)
+ * - 201 cross-class duplicate (owned target class)
+ *
+ * Pattern: mock requirePermission (not requireAuth), following
+ * src/app/api/admin/users/[id]/__tests__/route.test.ts.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { POST } from '../route';
+import { createStorage } from '@/server/persistence';
+import { getClassRepository } from '@/server/classes';
+import { requirePermission, getNamespaceContext } from '@/server/auth/api-helpers';
+import { rateLimit } from '@/server/rate-limit';
+import type { User } from '@/server/auth/types';
+import { RBACService } from '@/server/auth/rbac';
+
+// Mock dependencies
+jest.mock('@/server/persistence');
+jest.mock('@/server/classes');
+jest.mock('@/server/rate-limit');
+jest.mock('@/server/auth/api-helpers', () => ({
+  requirePermission: jest.fn(),
+  getNamespaceContext: jest.fn((req: any, user: any) => user.namespaceId || 'default'),
+}));
+
+const mockCreateStorage = createStorage as jest.MockedFunction<typeof createStorage>;
+const mockGetClassRepository = getClassRepository as jest.MockedFunction<typeof getClassRepository>;
+const mockRequirePermission = requirePermission as jest.MockedFunction<typeof requirePermission>;
+const mockRateLimit = rateLimit as jest.MockedFunction<typeof rateLimit>;
+
+function createAuthContext(user: User) {
+  return {
+    user,
+    accessToken: 'test-access-token',
+    rbac: new RBACService(),
+  };
+}
+
+describe('POST /api/problems/[id]/duplicate', () => {
+  const mockInstructor: User = {
+    id: 'instructor-1',
+    email: 'instructor@test.com',
+    role: 'instructor' as const,
+    namespaceId: 'ns-default',
+    createdAt: new Date('2025-01-01'),
+  };
+
+  const mockStudent: User = {
+    id: 'student-1',
+    email: 'student@test.com',
+    role: 'student' as const,
+    namespaceId: 'ns-default',
+    createdAt: new Date('2025-01-01'),
+  };
+
+  const mockSourceProblem = {
+    id: 'problem-source',
+    title: 'Original Problem',
+    description: 'A description',
+    starterCode: 'print("hello")',
+    testCases: [],
+    authorId: 'instructor-1',
+    classId: 'class-A',
+    namespaceId: 'ns-default',
+    tags: [],
+    createdAt: new Date('2025-01-01'),
+    updatedAt: new Date('2025-01-01'),
+  };
+
+  const mockDuplicatedProblem = {
+    ...mockSourceProblem,
+    id: 'problem-copy',
+    title: 'Copy of Original Problem',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+
+  function makeRequest(body: object) {
+    return new NextRequest('http://localhost/api/problems/problem-source/duplicate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Default: rate limiter allows
+    mockRateLimit.mockResolvedValue(null);
+  });
+
+  it('should return 401 when requirePermission returns unauthenticated response', async () => {
+    /**
+     * Verifies that the route propagates the 401 from the auth gate.
+     * Catches: missing or bypassed requirePermission call.
+     */
+    mockRequirePermission.mockResolvedValue(
+      NextResponse.json({ error: 'Not authenticated' }, { status: 401 })
+    );
+
+    const response = await POST(makeRequest({ title: 'Copy' }), {
+      params: Promise.resolve({ id: 'problem-source' }),
+    });
+
+    expect(response.status).toBe(401);
+  });
+
+  it('should return 403 when user is a student (lacks problem.create permission)', async () => {
+    /**
+     * Verifies that students cannot duplicate problems.
+     * requirePermission('problem.create') returns 403 for students.
+     * Catches: missing role gate; wrong permission checked.
+     */
+    mockRequirePermission.mockResolvedValue(
+      NextResponse.json(
+        { error: 'Forbidden: Requires problem.create permission' },
+        { status: 403 }
+      )
+    );
+
+    const mockDuplicateFn = jest.fn();
+    mockCreateStorage.mockResolvedValue({
+      problems: { getById: jest.fn(), duplicate: mockDuplicateFn },
+    } as any);
+
+    const response = await POST(makeRequest({ title: 'Copy' }), {
+      params: Promise.resolve({ id: 'problem-source' }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(mockDuplicateFn).not.toHaveBeenCalled();
+  });
+
+  it('should return 400 when title is blank or whitespace-only', async () => {
+    /**
+     * Verifies title validation before any DB calls.
+     * Catches: missing blank-title guard; whitespace not trimmed.
+     */
+    mockRequirePermission.mockResolvedValue(createAuthContext(mockInstructor));
+
+    const mockDuplicateFn = jest.fn();
+    mockCreateStorage.mockResolvedValue({
+      problems: { getById: jest.fn(), duplicate: mockDuplicateFn },
+    } as any);
+
+    const response = await POST(makeRequest({ title: '   ' }), {
+      params: Promise.resolve({ id: 'problem-source' }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error).toBe('Title is required');
+    expect(mockDuplicateFn).not.toHaveBeenCalled();
+  });
+
+  it('should return 404 when source problem is not found', async () => {
+    /**
+     * Verifies namespace-scoped source lookup returns 404 on miss.
+     * Catches: missing null check; namespace not passed to getById.
+     */
+    mockRequirePermission.mockResolvedValue(createAuthContext(mockInstructor));
+
+    const mockDuplicateFn = jest.fn();
+    mockCreateStorage.mockResolvedValue({
+      problems: {
+        getById: jest.fn().mockResolvedValue(null),
+        duplicate: mockDuplicateFn,
+      },
+    } as any);
+
+    const response = await POST(makeRequest({ title: 'Copy' }), {
+      params: Promise.resolve({ id: 'problem-source' }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(data.error).toBe('Problem not found');
+    expect(mockDuplicateFn).not.toHaveBeenCalled();
+  });
+
+  it('should return 201 for same-class duplicate with no targetClassId', async () => {
+    /**
+     * Verifies the happy path: same-class copy authored by the requesting instructor.
+     * duplicate must be called with { title, classId: source.classId, authorId: user.id }.
+     * Catches: authorId not set to current user; classId defaulting wrong.
+     */
+    mockRequirePermission.mockResolvedValue(createAuthContext(mockInstructor));
+
+    const mockGetById = jest.fn().mockResolvedValue(mockSourceProblem);
+    const mockDuplicateFn = jest.fn().mockResolvedValue(mockDuplicatedProblem);
+    mockCreateStorage.mockResolvedValue({
+      problems: { getById: mockGetById, duplicate: mockDuplicateFn },
+    } as any);
+
+    const response = await POST(makeRequest({ title: 'Copy of Original Problem' }), {
+      params: Promise.resolve({ id: 'problem-source' }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(data.problem).toBeDefined();
+    expect(mockDuplicateFn).toHaveBeenCalledWith('problem-source', {
+      title: 'Copy of Original Problem',
+      classId: mockSourceProblem.classId,
+      authorId: mockInstructor.id,
+    });
+  });
+
+  it('should return 201 for cross-class duplicate when instructor owns the target class', async () => {
+    /**
+     * Verifies that an instructor can port a problem to a class they own.
+     * Verifies that duplicate is called with the targetClassId, not the source classId.
+     * Catches: targetClassId ignored; ownership check wrongly blocking owned class.
+     */
+    mockRequirePermission.mockResolvedValue(createAuthContext(mockInstructor));
+
+    const mockGetById = jest.fn().mockResolvedValue(mockSourceProblem);
+    const mockDuplicateFn = jest.fn().mockResolvedValue({
+      ...mockDuplicatedProblem,
+      classId: 'class-B',
+    });
+    mockCreateStorage.mockResolvedValue({
+      problems: { getById: mockGetById, duplicate: mockDuplicateFn },
+    } as any);
+
+    const mockTargetClass = {
+      id: 'class-B',
+      createdBy: mockInstructor.id,
+      namespaceId: 'ns-default',
+    };
+    const mockClassRepo = {
+      getClass: jest.fn().mockResolvedValue(mockTargetClass),
+    };
+    mockGetClassRepository.mockReturnValue(mockClassRepo as any);
+
+    const response = await POST(
+      makeRequest({ title: 'Copy', targetClassId: 'class-B' }),
+      { params: Promise.resolve({ id: 'problem-source' }) }
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(mockDuplicateFn).toHaveBeenCalledWith('problem-source', {
+      title: 'Copy',
+      classId: 'class-B',
+      authorId: mockInstructor.id,
+    });
+  });
+
+  it('should return 403 when instructor does not own the target class', async () => {
+    /**
+     * Verifies that an instructor cannot port a problem to a class they do not own.
+     * The createdBy check is a custom authorization layer on top of requirePermission.
+     * Catches: ownership check missing; wrong field compared.
+     */
+    mockRequirePermission.mockResolvedValue(createAuthContext(mockInstructor));
+
+    const mockGetById = jest.fn().mockResolvedValue(mockSourceProblem);
+    const mockDuplicateFn = jest.fn();
+    mockCreateStorage.mockResolvedValue({
+      problems: { getById: mockGetById, duplicate: mockDuplicateFn },
+    } as any);
+
+    const mockTargetClass = {
+      id: 'class-B',
+      createdBy: 'someone-else',
+      namespaceId: 'ns-default',
+    };
+    const mockClassRepo = {
+      getClass: jest.fn().mockResolvedValue(mockTargetClass),
+    };
+    mockGetClassRepository.mockReturnValue(mockClassRepo as any);
+
+    const response = await POST(
+      makeRequest({ title: 'Copy', targetClassId: 'class-B' }),
+      { params: Promise.resolve({ id: 'problem-source' }) }
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(data.error).toBe('You do not own the target class');
+    expect(mockDuplicateFn).not.toHaveBeenCalled();
+  });
+
+  it('should return 404 when target class is not found', async () => {
+    /**
+     * Verifies that a non-existent (or out-of-namespace) target class yields 404.
+     * Catches: null not handled; missing namespace filter on getClass.
+     */
+    mockRequirePermission.mockResolvedValue(createAuthContext(mockInstructor));
+
+    const mockGetById = jest.fn().mockResolvedValue(mockSourceProblem);
+    const mockDuplicateFn = jest.fn();
+    mockCreateStorage.mockResolvedValue({
+      problems: { getById: mockGetById, duplicate: mockDuplicateFn },
+    } as any);
+
+    const mockClassRepo = {
+      getClass: jest.fn().mockResolvedValue(null),
+    };
+    mockGetClassRepository.mockReturnValue(mockClassRepo as any);
+
+    const response = await POST(
+      makeRequest({ title: 'Copy', targetClassId: 'class-nonexistent' }),
+      { params: Promise.resolve({ id: 'problem-source' }) }
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(data.error).toBe('Target class not found');
+    expect(mockDuplicateFn).not.toHaveBeenCalled();
+  });
+
+  it('should skip class ownership check for namespace-admin targeting any class', async () => {
+    /**
+     * Verifies that namespace-admins can duplicate to any class in their namespace
+     * without the createdBy ownership check.
+     * Catches: ownership check incorrectly applied to admins.
+     */
+    const mockAdmin: User = {
+      id: 'admin-1',
+      email: 'admin@test.com',
+      role: 'namespace-admin' as const,
+      namespaceId: 'ns-default',
+      createdAt: new Date('2025-01-01'),
+    };
+    mockRequirePermission.mockResolvedValue(createAuthContext(mockAdmin));
+
+    const mockGetById = jest.fn().mockResolvedValue(mockSourceProblem);
+    const mockDuplicateFn = jest.fn().mockResolvedValue({
+      ...mockDuplicatedProblem,
+      classId: 'class-B',
+      authorId: mockAdmin.id,
+    });
+    mockCreateStorage.mockResolvedValue({
+      problems: { getById: mockGetById, duplicate: mockDuplicateFn },
+    } as any);
+
+    // Class is owned by someone else — admin should still be allowed
+    const mockTargetClass = {
+      id: 'class-B',
+      createdBy: 'another-instructor',
+      namespaceId: 'ns-default',
+    };
+    const mockClassRepo = {
+      getClass: jest.fn().mockResolvedValue(mockTargetClass),
+    };
+    mockGetClassRepository.mockReturnValue(mockClassRepo as any);
+
+    const response = await POST(
+      makeRequest({ title: 'Admin Copy', targetClassId: 'class-B' }),
+      { params: Promise.resolve({ id: 'problem-source' }) }
+    );
+
+    expect(response.status).toBe(201);
+    expect(mockDuplicateFn).toHaveBeenCalledWith('problem-source', {
+      title: 'Admin Copy',
+      classId: 'class-B',
+      authorId: mockAdmin.id,
+    });
+  });
+});

--- a/src/app/api/problems/[id]/duplicate/__tests__/route.test.ts
+++ b/src/app/api/problems/[id]/duplicate/__tests__/route.test.ts
@@ -167,14 +167,17 @@ describe('POST /api/problems/[id]/duplicate', () => {
   it('should return 404 when source problem is not found', async () => {
     /**
      * Verifies namespace-scoped source lookup returns 404 on miss.
+     * Also asserts namespaceId is forwarded to getById — if omitted, a problem
+     * from another namespace could be resolved, leaking cross-tenant data.
      * Catches: missing null check; namespace not passed to getById.
      */
     mockRequirePermission.mockResolvedValue(createAuthContext(mockInstructor));
 
+    const mockGetById = jest.fn().mockResolvedValue(null);
     const mockDuplicateFn = jest.fn();
     mockCreateStorage.mockResolvedValue({
       problems: {
-        getById: jest.fn().mockResolvedValue(null),
+        getById: mockGetById,
         duplicate: mockDuplicateFn,
       },
     } as any);
@@ -187,13 +190,17 @@ describe('POST /api/problems/[id]/duplicate', () => {
     expect(response.status).toBe(404);
     expect(data.error).toBe('Problem not found');
     expect(mockDuplicateFn).not.toHaveBeenCalled();
+    // Namespace must be forwarded so cross-tenant problems are never resolved.
+    expect(mockGetById).toHaveBeenCalledWith('problem-source', 'ns-default');
   });
 
   it('should return 201 for same-class duplicate with no targetClassId', async () => {
     /**
      * Verifies the happy path: same-class copy authored by the requesting instructor.
      * duplicate must be called with { title, classId: source.classId, authorId: user.id }.
-     * Catches: authorId not set to current user; classId defaulting wrong.
+     * Also asserts the route calls requirePermission with 'problem.create' — if it were
+     * changed to 'problem.read' (which students have), all other tests would still pass.
+     * Catches: authorId not set to current user; classId defaulting wrong; wrong permission.
      */
     mockRequirePermission.mockResolvedValue(createAuthContext(mockInstructor));
 
@@ -215,6 +222,8 @@ describe('POST /api/problems/[id]/duplicate', () => {
       classId: mockSourceProblem.classId,
       authorId: mockInstructor.id,
     });
+    // Gate on exact permission string: students have problem.read but NOT problem.create.
+    expect(mockRequirePermission).toHaveBeenCalledWith(expect.anything(), 'problem.create');
   });
 
   it('should return 201 for cross-class duplicate when instructor owns the target class', async () => {
@@ -296,6 +305,8 @@ describe('POST /api/problems/[id]/duplicate', () => {
   it('should return 404 when target class is not found', async () => {
     /**
      * Verifies that a non-existent (or out-of-namespace) target class yields 404.
+     * Also asserts namespaceId is forwarded to getClass — without it, a class from
+     * another tenant could be resolved, enabling cross-tenant problem porting.
      * Catches: null not handled; missing namespace filter on getClass.
      */
     mockRequirePermission.mockResolvedValue(createAuthContext(mockInstructor));
@@ -320,6 +331,66 @@ describe('POST /api/problems/[id]/duplicate', () => {
     expect(response.status).toBe(404);
     expect(data.error).toBe('Target class not found');
     expect(mockDuplicateFn).not.toHaveBeenCalled();
+    // Namespace must be forwarded to prevent cross-tenant class resolution.
+    expect(mockClassRepo.getClass).toHaveBeenCalledWith('class-nonexistent', 'ns-default');
+  });
+
+  it('should call duplicate with trimmed title when title has surrounding whitespace', async () => {
+    /**
+     * Verifies that title.trim() is applied before storing: a title of '  Foo  '
+     * must reach the repository as 'Foo'. Without this, stored titles would
+     * carry invisible leading/trailing spaces.
+     */
+    mockRequirePermission.mockResolvedValue(createAuthContext(mockInstructor));
+
+    const mockGetById = jest.fn().mockResolvedValue(mockSourceProblem);
+    const mockDuplicateFn = jest.fn().mockResolvedValue({ ...mockDuplicatedProblem, title: 'Foo' });
+    mockCreateStorage.mockResolvedValue({
+      problems: { getById: mockGetById, duplicate: mockDuplicateFn },
+    } as any);
+
+    const response = await POST(makeRequest({ title: '  Foo  ' }), {
+      params: Promise.resolve({ id: 'problem-source' }),
+    });
+
+    expect(response.status).toBe(201);
+    expect(mockDuplicateFn).toHaveBeenCalledWith('problem-source', {
+      title: 'Foo',
+      classId: mockSourceProblem.classId,
+      authorId: mockInstructor.id,
+    });
+  });
+
+  it('should skip class lookup when targetClassId equals source.classId', async () => {
+    /**
+     * Verifies the same-class short-circuit: when targetClassId === source.classId,
+     * the route skips getClass and ownership checks and duplicates within the same class.
+     * Catches: unnecessary ownership check blocking same-class duplicate with targetClassId set;
+     * or, missing short-circuit causing a wasted DB lookup.
+     */
+    mockRequirePermission.mockResolvedValue(createAuthContext(mockInstructor));
+
+    const mockGetById = jest.fn().mockResolvedValue(mockSourceProblem);
+    const mockDuplicateFn = jest.fn().mockResolvedValue(mockDuplicatedProblem);
+    mockCreateStorage.mockResolvedValue({
+      problems: { getById: mockGetById, duplicate: mockDuplicateFn },
+    } as any);
+
+    // Pass targetClassId equal to source.classId ('class-A')
+    const response = await POST(
+      makeRequest({ title: 'Same Class Copy', targetClassId: mockSourceProblem.classId }),
+      { params: Promise.resolve({ id: 'problem-source' }) }
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(201);
+    // getClassRepository must NOT be called — no ownership check needed
+    expect(mockGetClassRepository).not.toHaveBeenCalled();
+    expect(mockDuplicateFn).toHaveBeenCalledWith('problem-source', {
+      title: 'Same Class Copy',
+      classId: mockSourceProblem.classId,
+      authorId: mockInstructor.id,
+    });
   });
 
   it('should skip class ownership check for namespace-admin targeting any class', async () => {

--- a/src/app/api/problems/[id]/duplicate/route.ts
+++ b/src/app/api/problems/[id]/duplicate/route.ts
@@ -1,0 +1,107 @@
+/**
+ * POST /api/problems/[id]/duplicate
+ *
+ * Duplicate a problem, optionally porting it to another class.
+ *
+ * The copy is always authored by the requesting user (authorId = current user),
+ * regardless of who authored the source. This ensures the copier has RLS-backed
+ * ownership over the duplicate.
+ *
+ * Authorization:
+ * - Requires problem.create permission (instructor / namespace-admin / system-admin).
+ * - When targetClassId is provided: instructor must own the target class
+ *   (classes.createdBy === user.id). namespace-admin and system-admin skip this check.
+ *
+ * Request body: { title: string (required, non-blank), targetClassId?: string }
+ * Responses:
+ *   201 { problem }
+ *   400 blank title
+ *   401 unauthenticated
+ *   403 student, or target class not owned by instructor
+ *   404 source problem not visible in namespace, or target class not found
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { createStorage } from '@/server/persistence';
+import { requirePermission, getNamespaceContext } from '@/server/auth/api-helpers';
+import { getClassRepository } from '@/server/classes';
+import { rateLimit } from '@/server/rate-limit';
+
+type Params = {
+  params: Promise<{
+    id: string;
+  }>;
+};
+
+export async function POST(request: NextRequest, { params }: Params) {
+  try {
+    const { id } = await params;
+
+    // Auth gate: only users with problem.create permission may duplicate problems.
+    // Students have problem.read but NOT problem.create, so they receive 403 here.
+    const auth = await requirePermission(request, 'problem.create');
+    if (auth instanceof NextResponse) {
+      return auth;
+    }
+
+    const { user, accessToken } = auth;
+
+    // Rate limit write operations by user ID.
+    const limited = await rateLimit('write', request, user.id);
+    if (limited) return limited;
+
+    // Parse and validate body.
+    const body = await request.json();
+    const { title, targetClassId } = body as { title?: string; targetClassId?: string };
+
+    if (!title || title.trim() === '') {
+      return NextResponse.json({ error: 'Title is required' }, { status: 400 });
+    }
+
+    const namespaceId = getNamespaceContext(request, user);
+    const storage = await createStorage(accessToken);
+
+    // Verify the source problem is visible in the caller's namespace.
+    const source = await storage.problems.getById(id, namespaceId);
+    if (!source) {
+      return NextResponse.json({ error: 'Problem not found' }, { status: 404 });
+    }
+
+    // Resolve target class: validate ownership when a cross-class port is requested.
+    let resolvedClassId = source.classId;
+
+    if (targetClassId && targetClassId !== source.classId) {
+      const classRepo = getClassRepository(accessToken);
+      const targetClass = await classRepo.getClass(targetClassId, namespaceId);
+
+      if (!targetClass) {
+        return NextResponse.json({ error: 'Target class not found' }, { status: 404 });
+      }
+
+      // Custom ownership check: instructors may only target their own classes.
+      // namespace-admin and system-admin skip this check (they manage any class in scope).
+      if (user.role === 'instructor' && targetClass.createdBy !== user.id) {
+        return NextResponse.json(
+          { error: 'You do not own the target class' },
+          { status: 403 }
+        );
+      }
+
+      resolvedClassId = targetClassId;
+    }
+
+    const problem = await storage.problems.duplicate(id, {
+      title: title.trim(),
+      classId: resolvedClassId,
+      authorId: user.id,
+    });
+
+    return NextResponse.json({ problem }, { status: 201 });
+  } catch (error: any) {
+    console.error('Error duplicating problem:', error);
+    return NextResponse.json(
+      { error: error.message || 'Failed to duplicate problem' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/server/persistence/interfaces.ts
+++ b/src/server/persistence/interfaces.ts
@@ -296,16 +296,19 @@ export interface IProblemRepository {
   getByClass(classId: string, filter?: ProblemFilter, namespaceId?: string): Promise<ProblemMetadata[]>;
 
   /**
-   * Duplicate a problem with new title
+   * Duplicate a problem with overrides applied to the copy.
    *
-   * Creates a copy with new ID and specified title.
+   * Creates a copy with a new ID. The title is required; classId and authorId
+   * default to the source problem's values when not provided.
+   * All other fields (description, starterCode, testCases, executionSettings,
+   * tags, solution, namespaceId) are copied verbatim from the source.
    *
-   * @param id - Problem to duplicate
-   * @param newTitle - Title for the duplicate
+   * @param id - ID of the problem to duplicate
+   * @param overrides - title is required; classId/authorId are optional overrides
    * @returns The duplicated problem
-   * @throws {PersistenceError} with NOT_FOUND if problem doesn't exist
+   * @throws {Error} with 'Problem not found: <id>' if problem doesn't exist
    */
-  duplicate(id: string, newTitle: string): Promise<Problem>;
+  duplicate(id: string, overrides: { title: string; classId?: string; authorId?: string }): Promise<Problem>;
 }
 
 /**

--- a/src/server/persistence/supabase/__tests__/problem-duplicate-integration.test.ts
+++ b/src/server/persistence/supabase/__tests__/problem-duplicate-integration.test.ts
@@ -83,7 +83,15 @@ describeIfSupabase('Problem Duplicate: RLS Integration', () => {
       throw new Error(`seedUser: failed to create profile ${email}: ${profileError.message}`);
     }
 
-    const { data: signIn, error: signInError } = await admin.auth.signInWithPassword({
+    // Sign in on a SEPARATE throwaway client so the service-role `admin` client
+    // is never mutated by a user JWT. Calling signInWithPassword on the shared
+    // admin client would overwrite its in-memory session (even with persistSession:
+    // false), causing subsequent service-role inserts to run as the signed-in user
+    // and hit RLS policies that block them.
+    const signInClient = createClient(supabaseUrl!, serviceRoleKey!, {
+      auth: { persistSession: false, autoRefreshToken: false },
+    });
+    const { data: signIn, error: signInError } = await signInClient.auth.signInWithPassword({
       email,
       password: TEST_PASSWORD,
     });

--- a/src/server/persistence/supabase/__tests__/problem-duplicate-integration.test.ts
+++ b/src/server/persistence/supabase/__tests__/problem-duplicate-integration.test.ts
@@ -1,0 +1,358 @@
+/**
+ * Real-DB integration tests: problem duplicate authorship + RLS enforcement
+ *
+ * IMPORTANT — SKIPS IN CI TODAY: These tests run against a live local Supabase
+ * instance. The default ci.yml test job sets no SUPABASE_SECRET_KEY and starts
+ * no DB, so this suite is skipped there via the `describeIfSupabase` gate below.
+ * Making these gate in CI is tracked by bead coding-wsw.
+ *
+ * To run locally:
+ *   npx supabase start
+ *   source .env.local
+ *   npm test -- problem-duplicate-integration
+ *
+ * Why these tests require a real DB:
+ * The whole point of setting authorId = copier on duplicate is so Postgres RLS
+ * lets the copier edit/delete their copy:
+ *   problems UPDATE policy: author_id = auth.uid() OR is_system_admin()
+ *   problems DELETE policy: author_id = auth.uid() OR is_system_admin()
+ * Mocked unit/route tests verify the input shape fed to insert, but CANNOT prove
+ * the DB persisted the right author_id or that RLS actually grants/denies write
+ * access. This suite exercises real authenticated JWT clients against live Postgres.
+ */
+
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
+import { SupabaseProblemRepository } from '../problem-repository';
+import { Problem } from '../../../types/problem';
+
+// setupTests.ts globally mocks @/server/supabase/client for unit tests.
+// Undo that mock so this real-DB suite uses the actual Supabase client.
+jest.mock('@/server/supabase/client', () =>
+  jest.requireActual('@/server/supabase/client')
+);
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const serviceRoleKey = process.env.SUPABASE_SECRET_KEY;
+const hasSupabaseCredentials = Boolean(supabaseUrl && serviceRoleKey);
+
+const describeIfSupabase = hasSupabaseCredentials ? describe : describe.skip;
+
+// Isolated namespace IDs for this test suite — avoids collisions with seed data
+const NS_A = 'dup-integ-ns-a';
+const NS_B = 'dup-integ-ns-b';
+const EMAIL_SUFFIX = '@dup-integ.local';
+const TEST_PASSWORD = 'TestPass123!';
+
+describeIfSupabase('Problem Duplicate: RLS Integration', () => {
+  let admin: SupabaseClient;
+
+  // Seeded actors
+  let userA: { id: string; accessToken: string }; // author of source problem; in NS_A
+  let userB: { id: string; accessToken: string }; // copier; in NS_A
+  let userC: { id: string; accessToken: string }; // instructor in NS_B (different namespace)
+
+  let classCA: { id: string }; // owned by A in NS_A
+  let classCB: { id: string }; // owned by B in NS_A
+
+  let problemA: Problem; // A's original problem in classCA
+
+  /**
+   * Create an auth user + user_profile and sign in to obtain a JWT access token
+   * so that SupabaseProblemRepository can be created with RLS-bound credentials.
+   */
+  async function seedUser(
+    email: string,
+    role: string,
+    namespaceId: string | null
+  ): Promise<{ id: string; accessToken: string }> {
+    const { data: authData, error: authError } = await admin.auth.admin.createUser({
+      email,
+      password: TEST_PASSWORD,
+      email_confirm: true,
+    });
+    if (authError || !authData.user) {
+      throw new Error(`seedUser: failed to create auth user ${email}: ${authError?.message}`);
+    }
+
+    const { error: profileError } = await admin.from('user_profiles').insert({
+      id: authData.user.id,
+      role,
+      namespace_id: namespaceId,
+    });
+    if (profileError) {
+      throw new Error(`seedUser: failed to create profile ${email}: ${profileError.message}`);
+    }
+
+    const { data: signIn, error: signInError } = await admin.auth.signInWithPassword({
+      email,
+      password: TEST_PASSWORD,
+    });
+    if (signInError || !signIn.session) {
+      throw new Error(`seedUser: sign-in failed for ${email}: ${signInError?.message}`);
+    }
+
+    return { id: authData.user.id, accessToken: signIn.session.access_token };
+  }
+
+  beforeAll(async () => {
+    admin = createClient(supabaseUrl!, serviceRoleKey!, {
+      auth: { autoRefreshToken: false, persistSession: false },
+    });
+
+    // Seed namespaces (idempotent)
+    const namespacesToSeed = [
+      { id: NS_A, display_name: 'Dup Integ Namespace A' },
+      { id: NS_B, display_name: 'Dup Integ Namespace B' },
+    ];
+    for (const ns of namespacesToSeed) {
+      const { error } = await admin.from('namespaces').upsert(ns, { onConflict: 'id' });
+      if (error) throw new Error(`beforeAll: failed to upsert namespace ${ns.id}: ${error.message}`);
+    }
+
+    // Seed instructors: A and B in NS_A, C in NS_B
+    userA = await seedUser(`instructor-a${EMAIL_SUFFIX}`, 'instructor', NS_A);
+    userB = await seedUser(`instructor-b${EMAIL_SUFFIX}`, 'instructor', NS_A);
+    userC = await seedUser(`instructor-c${EMAIL_SUFFIX}`, 'instructor', NS_B);
+
+    // Seed classes via admin (bypasses classes INSERT RLS for setup convenience)
+    const { data: caData, error: caErr } = await admin
+      .from('classes')
+      .insert({ namespace_id: NS_A, name: 'Class A', created_by: userA.id })
+      .select('id')
+      .single();
+    if (caErr || !caData) throw new Error(`beforeAll: failed to create class CA: ${caErr?.message}`);
+    classCA = { id: caData.id };
+
+    const { data: cbData, error: cbErr } = await admin
+      .from('classes')
+      .insert({ namespace_id: NS_A, name: 'Class B', created_by: userB.id })
+      .select('id')
+      .single();
+    if (cbErr || !cbData) throw new Error(`beforeAll: failed to create class CB: ${cbErr?.message}`);
+    classCB = { id: cbData.id };
+
+    // Seed A's problem using A's authenticated repository.
+    // This also exercises the problems INSERT RLS (instructor_or_higher + same namespace).
+    const repoA = new SupabaseProblemRepository(userA.accessToken);
+    problemA = await repoA.create({
+      namespaceId: NS_A,
+      title: 'Original Problem by A',
+      description: 'Source problem for duplication integration tests',
+      starterCode: 'print("hello")',
+      authorId: userA.id,
+      classId: classCA.id,
+      tags: [],
+    });
+  });
+
+  afterAll(async () => {
+    // Delete all test auth users (ON DELETE CASCADE removes user_profiles)
+    const { data: authUsers } = await admin.auth.admin.listUsers();
+    for (const u of authUsers?.users ?? []) {
+      if (u.email?.endsWith(EMAIL_SUFFIX)) {
+        await admin.auth.admin.deleteUser(u.id);
+      }
+    }
+    // Delete namespaces (CASCADE removes classes and problems)
+    await admin.from('namespaces').delete().in('id', [NS_A, NS_B]);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Test Case 1: Copier owns the duplicate under RLS
+  //
+  // Contract: When B duplicates A's problem with authorId override = B,
+  //   • the copy's author_id and class_id reflect the overrides (DB-level, not just app-level)
+  //   • real Postgres RLS permits B to UPDATE and DELETE the copy
+  //     (problems UPDATE/DELETE: author_id = auth.uid())
+  //
+  // Catches: authorId not actually written at the DB layer; RLS blocking the
+  //          legitimate owner from editing their own copy.
+  // ---------------------------------------------------------------------------
+  describe('Copier owns the duplicate under RLS', () => {
+    it('copy has author_id = B and class_id = CB in the database', async () => {
+      /**
+       * Verifies the DB row has the overridden author_id and class_id.
+       * Mocked tests only verify the ProblemInput shape; real-DB confirms persistence.
+       */
+      const repoB = new SupabaseProblemRepository(userB.accessToken);
+      const copy = await repoB.duplicate(problemA.id, {
+        title: 'Copy of Original by B',
+        classId: classCB.id,
+        authorId: userB.id,
+      });
+
+      try {
+        expect(copy.authorId).toBe(userB.id);
+        expect(copy.classId).toBe(classCB.id);
+        expect(copy.title).toBe('Copy of Original by B');
+        expect(copy.namespaceId).toBe(NS_A);
+        // Confirm fields are a separate row (not the same id as original)
+        expect(copy.id).not.toBe(problemA.id);
+      } finally {
+        await admin.from('problems').delete().eq('id', copy.id);
+      }
+    });
+
+    it('B can UPDATE the copy — RLS: author_id = B = auth.uid()', async () => {
+      /**
+       * Verifies Postgres RLS permits the copier to update their copy.
+       * If authorId were not applied at the DB layer, this UPDATE would be blocked.
+       */
+      const repoB = new SupabaseProblemRepository(userB.accessToken);
+      const copy = await repoB.duplicate(problemA.id, {
+        title: 'Copy to Update',
+        classId: classCB.id,
+        authorId: userB.id,
+      });
+
+      try {
+        const updated = await repoB.update(copy.id, { title: 'Updated by B' });
+        expect(updated.title).toBe('Updated by B');
+        expect(updated.authorId).toBe(userB.id);
+      } finally {
+        await admin.from('problems').delete().eq('id', copy.id);
+      }
+    });
+
+    it('B can DELETE the copy — RLS: author_id = B = auth.uid()', async () => {
+      /**
+       * Verifies Postgres RLS permits the copier to delete their copy.
+       * Confirms the row is actually removed from the database.
+       */
+      const repoB = new SupabaseProblemRepository(userB.accessToken);
+      const copy = await repoB.duplicate(problemA.id, {
+        title: 'Copy to Delete',
+        classId: classCB.id,
+        authorId: userB.id,
+      });
+
+      await repoB.delete(copy.id);
+
+      // Confirm the row no longer exists
+      const { data } = await admin.from('problems').select('id').eq('id', copy.id);
+      expect(data).toHaveLength(0);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Test Case 2: Original unaffected; cross-author edit blocked by RLS
+  //
+  // Contract: Duplicating a problem creates a separate row; A's original is untouched.
+  //   Furthermore, RLS blocks B from editing A's original (author_id = A ≠ B = auth.uid()).
+  //
+  // Catches: accidental shared identity between source and copy; RLS regressions
+  //          that would allow cross-author writes.
+  // ---------------------------------------------------------------------------
+  describe('Original unaffected; cross-author edit blocked by RLS', () => {
+    it("A's original problem is a separate row unchanged by B's duplication", async () => {
+      /**
+       * Verifies duplicate() creates a new row and does not mutate the source.
+       * Fetches the original via admin to bypass RLS and confirm the DB state.
+       */
+      const repoB = new SupabaseProblemRepository(userB.accessToken);
+      const copy = await repoB.duplicate(problemA.id, {
+        title: 'Copy — verify original',
+        classId: classCB.id,
+        authorId: userB.id,
+      });
+
+      try {
+        const { data, error } = await admin
+          .from('problems')
+          .select('id, author_id, class_id, title')
+          .eq('id', problemA.id)
+          .single();
+
+        expect(error).toBeNull();
+        expect(data).not.toBeNull();
+        expect(data!.id).toBe(problemA.id);
+        expect(data!.author_id).toBe(userA.id);
+        expect(data!.class_id).toBe(classCA.id);
+        expect(data!.title).toBe('Original Problem by A');
+        expect(data!.id).not.toBe(copy.id);
+      } finally {
+        await admin.from('problems').delete().eq('id', copy.id);
+      }
+    });
+
+    it("B cannot UPDATE A's original — RLS blocks (author_id = A ≠ B)", async () => {
+      /**
+       * Verifies Postgres RLS makes A's problem invisible to B for UPDATE.
+       * The update method returns PGRST116 (0 rows) → throws "Problem not found".
+       * The original title must remain unchanged.
+       */
+      const repoB = new SupabaseProblemRepository(userB.accessToken);
+
+      await expect(
+        repoB.update(problemA.id, { title: 'Hijacked by B' })
+      ).rejects.toThrow(/Problem not found/);
+
+      // Original title must be unchanged
+      const { data } = await admin
+        .from('problems')
+        .select('title')
+        .eq('id', problemA.id)
+        .single();
+      expect(data?.title).toBe('Original Problem by A');
+    });
+
+    it("B cannot DELETE A's original — RLS silently skips; row still exists", async () => {
+      /**
+       * Postgres RLS-blocked DELETE returns success with 0 rows deleted (no error).
+       * The repository's delete() method does not surface the 0-row case, so we
+       * verify survival by fetching the row via admin after B's delete attempt.
+       */
+      const repoB = new SupabaseProblemRepository(userB.accessToken);
+
+      // No error is thrown — RLS silently skips the row
+      await expect(repoB.delete(problemA.id)).resolves.not.toThrow();
+
+      // A's original must still exist
+      const { data } = await admin
+        .from('problems')
+        .select('id')
+        .eq('id', problemA.id)
+        .single();
+      expect(data?.id).toBe(problemA.id);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Test Case 3: Namespace isolation on source read
+  //
+  // Contract: RLS SELECT policy scopes problems to namespace_id = get_user_namespace_id().
+  //   Instructor C (in NS_B) cannot read A's problem (in NS_A) via getById, and therefore
+  //   cannot duplicate it.
+  //
+  // Catches: cross-namespace source leakage; RLS SELECT regression.
+  // ---------------------------------------------------------------------------
+  describe('Namespace isolation — cross-namespace source read blocked', () => {
+    it('C (in NS_B) cannot read A\'s problem from NS_A via getById', async () => {
+      /**
+       * RLS SELECT policy: namespace_id = get_user_namespace_id().
+       * C's JWT resolves to NS_B; A's problem is in NS_A → invisible to C.
+       * getById returns null, not an error, because RLS filters the row away.
+       */
+      const repoC = new SupabaseProblemRepository(userC.accessToken);
+
+      const result = await repoC.getById(problemA.id);
+      expect(result).toBeNull();
+    });
+
+    it('C cannot duplicate A\'s problem — read blocked by RLS before insert', async () => {
+      /**
+       * duplicate() calls getById(id) internally; RLS scopes C's SELECT to NS_B
+       * → getById returns null → duplicate() throws "Problem not found".
+       * This is the full end-to-end proof that namespace isolation prevents the flow.
+       */
+      const repoC = new SupabaseProblemRepository(userC.accessToken);
+
+      await expect(
+        repoC.duplicate(problemA.id, {
+          title: 'Stolen Copy',
+          authorId: userC.id,
+        })
+      ).rejects.toThrow(/Problem not found/);
+    });
+  });
+});

--- a/src/server/persistence/supabase/__tests__/problem-repository.test.ts
+++ b/src/server/persistence/supabase/__tests__/problem-repository.test.ts
@@ -786,7 +786,12 @@ describe('SupabaseProblemRepository', () => {
   });
 
   describe('duplicate', () => {
-    it('should duplicate a problem with new title', async () => {
+    it('should duplicate a problem with title override, preserving source classId and authorId', async () => {
+      /**
+       * Verifies that duplicate copies all source fields and applies the title override.
+       * classId and authorId default to the source values when not overridden.
+       * Catches: signature regression; dropped fields; wrong defaults.
+       */
       // First call: getById
       const getByIdSingle = jest.fn().mockResolvedValue({ data: mockProblemRow, error: null });
       const getByIdEq = jest.fn().mockReturnValue({ single: getByIdSingle });
@@ -815,12 +820,73 @@ describe('SupabaseProblemRepository', () => {
         }
       });
 
-      const result = await repository.duplicate(mockProblem.id, 'Duplicated Problem');
+      const result = await repository.duplicate(mockProblem.id, { title: 'Duplicated Problem' });
 
       expect(result.title).toBe('Duplicated Problem');
       expect(result.id).toBe('new-uuid-5678');
       expect(result.namespaceId).toBe(mockProblem.namespaceId);
       expect(result.authorId).toBe(mockProblem.authorId);
+      // Verify source classId is preserved when not overridden
+      const insertedRow = insertFn.mock.calls[0][0];
+      expect(insertedRow.class_id).toBe(mockProblem.classId);
+      expect(insertedRow.author_id).toBe(mockProblem.authorId);
+      expect(insertedRow.test_cases).toEqual(mockProblem.testCases);
+      expect(insertedRow.execution_settings).toEqual(mockProblem.executionSettings);
+      expect(insertedRow.tags).toEqual(mockProblem.tags);
+    });
+
+    it('should apply classId and authorId overrides', async () => {
+      /**
+       * Verifies that classId and authorId overrides take precedence over the source values.
+       * This is the core of the duplicate-for-new-owner use case (authorId = copier,
+       * classId = target class). Catches: overrides not applied; wrong field precedence.
+       */
+      const getByIdSingle = jest.fn().mockResolvedValue({ data: mockProblemRow, error: null });
+      const getByIdEq = jest.fn().mockReturnValue({ single: getByIdSingle });
+
+      const overriddenRow = {
+        ...mockProblemRow,
+        id: 'new-uuid-9999',
+        title: 'X',
+        class_id: 'class-B',
+        author_id: 'user-2',
+      };
+      const insertSingle = jest.fn().mockResolvedValue({ data: overriddenRow, error: null });
+      const insertSelect = jest.fn().mockReturnValue({ single: insertSingle });
+      const insertFn = jest.fn().mockReturnValue({ select: insertSelect });
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) {
+          return {
+            select: jest.fn().mockReturnValue({ eq: getByIdEq }),
+          };
+        } else {
+          return {
+            insert: insertFn,
+          };
+        }
+      });
+
+      const result = await repository.duplicate(mockProblem.id, {
+        title: 'X',
+        classId: 'class-B',
+        authorId: 'user-2',
+      });
+
+      expect(result.id).toBe('new-uuid-9999');
+      // Verify overrides are applied in the inserted row
+      const insertedRow = insertFn.mock.calls[0][0];
+      expect(insertedRow.title).toBe('X');
+      expect(insertedRow.class_id).toBe('class-B');
+      expect(insertedRow.author_id).toBe('user-2');
+      // Source fields still carried over
+      expect(insertedRow.description).toBe(mockProblem.description);
+      expect(insertedRow.starter_code).toBe(mockProblem.starterCode);
+      expect(insertedRow.test_cases).toEqual(mockProblem.testCases);
+      expect(insertedRow.execution_settings).toEqual(mockProblem.executionSettings);
+      expect(insertedRow.tags).toEqual(mockProblem.tags);
     });
 
     it('should throw error if original problem not found', async () => {
@@ -834,7 +900,7 @@ describe('SupabaseProblemRepository', () => {
         select: jest.fn().mockReturnValue({ eq: getByIdEq }),
       });
 
-      await expect(repository.duplicate('nonexistent', 'New Title')).rejects.toThrow(
+      await expect(repository.duplicate('nonexistent', { title: 'New Title' })).rejects.toThrow(
         'Problem not found: nonexistent'
       );
     });

--- a/src/server/persistence/supabase/problem-repository.ts
+++ b/src/server/persistence/supabase/problem-repository.ts
@@ -378,24 +378,29 @@ export class SupabaseProblemRepository implements IProblemRepository {
     return data ? data.map((row) => mapRowToProblemMetadata({ ...row, author_name: row.author_id })) : [];
   }
 
-  async duplicate(id: string, newTitle: string): Promise<Problem> {
-    // First, get the original problem
+  async duplicate(
+    id: string,
+    overrides: { title: string; classId?: string; authorId?: string }
+  ): Promise<Problem> {
+    // First, get the original problem (intentionally un-namespaced; namespace
+    // isolation is enforced at the route via getById(id, namespaceId) before
+    // duplicate is called).
     const original = await this.getById(id);
 
     if (!original) {
       throw new Error(`Problem not found: ${id}`);
     }
 
-    // Create a copy with new title and ID
+    // Build the copy: apply overrides; fall back to source values when not provided.
     const problemInput: ProblemInput = {
       namespaceId: original.namespaceId,
-      title: newTitle,
+      title: overrides.title,
       description: original.description,
       starterCode: original.starterCode,
       testCases: original.testCases,
       executionSettings: original.executionSettings,
-      authorId: original.authorId,
-      classId: original.classId,
+      authorId: overrides.authorId ?? original.authorId,
+      classId: overrides.classId ?? original.classId,
       tags: original.tags,
       solution: original.solution,
     };


### PR DESCRIPTION
## Summary
- Instructors can now duplicate any problem they can read in their namespace — both to clone within the same class (build off prior work) and to port a copy into another class they own (share across their own classes).
- The copy is authored by the **duplicating** instructor (`authorId = current user`), which is required so the copier can edit/delete their own copy under the problems RLS policy (`UPDATE/DELETE` gated on `author_id = auth.uid()`).

## Changes
- **Backend:** `POST /api/problems/[id]/duplicate` (gated by `requirePermission('problem.create')` + write rate-limit; namespace-scoped source lookup; custom target-class ownership check — instructors must own the target class, admins skip). Generalized `IProblemRepository.duplicate(id, { title, classId?, authorId? })`.
- **Frontend:** a "Duplicate" action on each problem card opens `DuplicateProblemModal` (prefilled "Copy of <title>", optional target-class dropdown defaulting to "Same class"); the library refreshes on success.
- **Tests:** route unit tests (full status-code matrix + permission-string/namespace-arg/trim assertions), repo unit tests, a real-DB `describeIfSupabase` RLS integration test (proves the copier owns the copy and cross-author writes are blocked under real Postgres), a ProblemLibrary wiring test, and two e2e acceptance tests (same-class build-off + cross-class port).

## Notes
- The real-DB integration test and e2e spec skip in CI today (no `SUPABASE_SECRET_KEY` there — tracked by coding-wsw); both were run and pass locally against live Supabase.
- `playwright.config.ts` now honors a `PORT` env var so e2e can target a fresh worktree server when port 3000 is occupied.

## Follow-ups filed (not in this PR)
- **coding-ig8:** `POST /api/problems` does no target-class ownership check (pre-existing asymmetry surfaced by this work); consider extracting a shared ownership helper.

## Test plan
- [x] `npx tsc --noEmit`, `npm run lint`, full `npm test` (3475 tests) pass
- [x] Real-DB integration suite ran (not skipped) and passed locally
- [x] Both e2e acceptance tests pass locally (`PORT=3001 npm run test:e2e -- problem-duplication`)

Beads: coding-33o, coding-33o.1, coding-33o.2, coding-33o.3, coding-33o.4, coding-sti, coding-euw

Generated with Claude Code